### PR TITLE
improve word function

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -41,14 +41,16 @@ def create_app(config_name=None):
     from app.routes.auth import auth_bp
     from app.routes.daily_words import daily_words_bp
     from app.routes.word_bank import word_bank_bp
+    from app.routes.daily_learning import daily_learning_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(daily_words_bp)
     app.register_blueprint(word_bank_bp)
+    app.register_blueprint(daily_learning_bp)
 
     # Create database tables and auto-seed on first run
     with app.app_context():
-        from app.models import user, word, word_bank, review_history  # noqa: F401
+        from app.models import user, word, word_bank, review_history, user_word_progress  # noqa: F401
         db.create_all()
         _seed_words_if_empty(app)
         if app.config.get('DEBUG'):
@@ -65,8 +67,9 @@ def _seed_words_if_empty(app):
     if Word.query.first() is not None:
         return
 
+    # __file__ = backend/app/__init__.py → up 3 levels to project root
     csv_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         'frontend', 'public', 'AWL', 'AWL.csv'
     )
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,8 @@ from app.models.speaking_session import SpeakingSession
 from app.models.chat_session import ChatSession
 from app.models.chat_message import ChatMessage
 from app.models.progress import Progress
+from app.models.review_history import ReviewHistory
+from app.models.user_word_progress import UserWordProgress
 
 
 @event.listens_for(Engine, 'connect')
@@ -29,4 +31,6 @@ __all__ = [
     'ChatSession',
     'ChatMessage',
     'Progress',
+    'ReviewHistory',
+    'UserWordProgress',
 ]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -62,6 +62,13 @@ class User(UserMixin, db.Model):
         passive_deletes=True,
         lazy=True
     )
+    word_progress = db.relationship(
+        'UserWordProgress',
+        back_populates='user',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+        lazy=True
+    )
 
     def __init__(self, username, email):
         self.username = username

--- a/backend/app/models/user_word_progress.py
+++ b/backend/app/models/user_word_progress.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone, date as date_type
+from app import db
+
+
+class UserWordProgress(db.Model):
+    __tablename__ = 'user_word_progress'
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'word_id', name='unique_user_word_progress'),
+        db.CheckConstraint(
+            "status IN ('pending', 'review', 'mastered')",
+            name='ck_user_word_progress_status'
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False
+    )
+    word_id = db.Column(
+        db.Integer,
+        db.ForeignKey('words.id', ondelete='CASCADE'),
+        nullable=False
+    )
+    status = db.Column(
+        db.String(20),
+        nullable=False,
+        default='pending',
+        server_default=db.text("'pending'")
+    )
+    assigned_date = db.Column(
+        db.Date,
+        nullable=False,
+        default=lambda: date_type.today()
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc)
+    )
+
+    user = db.relationship('User', back_populates='word_progress')
+    word = db.relationship('Word', back_populates='user_word_progress')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'word_id': self.word_id,
+            'text': self.word.text if self.word else None,
+            'definition': self.word.definition if self.word else None,
+            'example_sentence': self.word.example_sentence if self.word else None,
+            'part_of_speech': self.word.part_of_speech if self.word else None,
+            'difficulty_level': self.word.difficulty_level if self.word else None,
+            'status': self.status,
+            'assigned_date': self.assigned_date.isoformat() if self.assigned_date else None,
+        }

--- a/backend/app/models/word.py
+++ b/backend/app/models/word.py
@@ -37,6 +37,13 @@ class Word(db.Model):
         passive_deletes=True,
         lazy=True
     )
+    user_word_progress = db.relationship(
+        'UserWordProgress',
+        back_populates='word',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+        lazy=True
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/routes/daily_learning.py
+++ b/backend/app/routes/daily_learning.py
@@ -1,0 +1,300 @@
+from datetime import datetime, timezone, date as date_type
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from app import db
+from app.models.word import Word
+from app.models.user_word_progress import UserWordProgress
+from app.models.word_bank import WordBank
+
+daily_learning_bp = Blueprint('daily_learning', __name__, url_prefix='/api')
+
+
+@daily_learning_bp.route('/daily-learning/today', methods=['GET'])
+@login_required
+def get_today_words():
+    """Get today's learning words: carry-over pending + new words.
+
+    Assignment logic (prevents re-filling within the same day):
+    - carry_over: pending words from *previous* days
+    - assigned_today: all words assigned today (any status)
+    - today_target = daily_count - carry_over count
+    - new_needed = today_target - assigned_today (only if > 0)
+    """
+    daily_count = request.args.get('count', 10, type=int)
+    daily_count = max(1, min(daily_count, 50))
+    today = date_type.today()
+
+    # Carry-over: pending words assigned BEFORE today
+    carryover = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.status == 'pending',
+        UserWordProgress.assigned_date < today
+    ).all()
+    carryover_count = len(carryover)
+
+    # Words assigned today (any status: pending, review, mastered)
+    assigned_today_count = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.assigned_date == today
+    ).count()
+
+    # How many new words should be assigned today
+    today_target = max(0, daily_count - carryover_count)
+    new_needed = max(0, today_target - assigned_today_count)
+
+    if new_needed > 0:
+        # Get word IDs already in progress for this user
+        existing_word_ids = db.session.query(UserWordProgress.word_id).filter_by(
+            user_id=current_user.id
+        ).all()
+        existing_ids = {row[0] for row in existing_word_ids}
+
+        # Get new words not yet assigned
+        query = Word.query
+        if existing_ids:
+            query = query.filter(Word.id.notin_(existing_ids))
+        available_words = query.order_by(Word.id).limit(new_needed).all()
+
+        for word in available_words:
+            progress = UserWordProgress(
+                user_id=current_user.id,
+                word_id=word.id,
+                status='pending',
+                assigned_date=today
+            )
+            db.session.add(progress)
+
+        db.session.commit()
+
+    # Return all currently pending words (carry-over + today's remaining)
+    pending = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='pending'
+    ).all()
+
+    review_count = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='review'
+    ).count()
+
+    mastered_count = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='mastered'
+    ).count()
+
+    total_words = Word.query.count()
+
+    return jsonify({
+        'date': today.isoformat(),
+        'words': [p.to_dict() for p in pending],
+        'pending_count': len(pending),
+        'review_count': review_count,
+        'mastered_count': mastered_count,
+        'total_words': total_words,
+    }), 200
+
+
+@daily_learning_bp.route('/daily-learning/word-status', methods=['POST'])
+@login_required
+def update_word_status():
+    """Update a word's learning status."""
+    data = request.get_json()
+    progress_id = data.get('progress_id')
+    new_status = data.get('status')
+
+    if not progress_id or new_status not in ('review', 'mastered', 'pending'):
+        return jsonify({'error': 'progress_id and valid status required'}), 400
+
+    progress = UserWordProgress.query.filter_by(
+        id=progress_id,
+        user_id=current_user.id
+    ).first()
+
+    if not progress:
+        return jsonify({'error': 'Not found'}), 404
+
+    progress.status = new_status
+    progress.updated_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    return jsonify(progress.to_dict()), 200
+
+
+@daily_learning_bp.route('/daily-learning/review-words', methods=['GET'])
+@login_required
+def get_review_words():
+    """Get all words marked for review."""
+    words = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='review'
+    ).order_by(UserWordProgress.updated_at.desc()).all()
+
+    return jsonify({
+        'words': [w.to_dict() for w in words],
+        'count': len(words)
+    }), 200
+
+
+@daily_learning_bp.route('/daily-learning/mastered-words', methods=['GET'])
+@login_required
+def get_mastered_words():
+    """Get all words marked as mastered."""
+    words = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='mastered'
+    ).order_by(UserWordProgress.updated_at.desc()).all()
+
+    return jsonify({
+        'words': [w.to_dict() for w in words],
+        'count': len(words)
+    }), 200
+
+
+@daily_learning_bp.route('/daily-learning/all-words', methods=['GET'])
+@login_required
+def get_all_words():
+    """Get all available words with user's progress status."""
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 50, type=int)
+    search = request.args.get('search', '', type=str)
+
+    query = Word.query
+    if search:
+        query = query.filter(
+            db.or_(
+                Word.text.ilike(f'%{search}%'),
+                Word.definition.ilike(f'%{search}%')
+            )
+        )
+
+    total = query.count()
+    words = query.order_by(Word.id).offset((page - 1) * per_page).limit(per_page).all()
+
+    # Get user's progress for these words
+    word_ids = [w.id for w in words]
+    progress_map = {}
+    if word_ids:
+        progress_entries = UserWordProgress.query.filter(
+            UserWordProgress.user_id == current_user.id,
+            UserWordProgress.word_id.in_(word_ids)
+        ).all()
+        progress_map = {p.word_id: p.status for p in progress_entries}
+
+    # Check which words are in word bank
+    bank_set = set()
+    if word_ids:
+        bank_entries = WordBank.query.filter(
+            WordBank.user_id == current_user.id,
+            WordBank.word_id.in_(word_ids)
+        ).all()
+        bank_set = {b.word_id for b in bank_entries}
+
+    result = []
+    for w in words:
+        d = w.to_dict()
+        d['progress_status'] = progress_map.get(w.id, None)
+        d['in_word_bank'] = w.id in bank_set
+        result.append(d)
+
+    return jsonify({
+        'words': result,
+        'total': total,
+        'page': page,
+        'per_page': per_page
+    }), 200
+
+
+@daily_learning_bp.route('/daily-learning/stats', methods=['GET'])
+@login_required
+def get_learning_stats():
+    """Get learning statistics for home page."""
+    mastered_count = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='mastered'
+    ).count()
+
+    review_count = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='review'
+    ).count()
+
+    pending_count = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        status='pending'
+    ).count()
+
+    total_learned = mastered_count + review_count
+    total_words = Word.query.count()
+    word_bank_count = WordBank.query.filter_by(user_id=current_user.id).count()
+
+    return jsonify({
+        'mastered': mastered_count,
+        'review': review_count,
+        'pending': pending_count,
+        'total_learned': total_learned,
+        'total_words': total_words,
+        'word_bank_count': word_bank_count,
+    }), 200
+
+
+@daily_learning_bp.route('/daily-learning/mark-mastered', methods=['POST'])
+@login_required
+def mark_word_mastered():
+    """Mark a word as mastered by word_id. Creates progress entry if needed."""
+    data = request.get_json()
+    word_id = data.get('word_id')
+
+    if not word_id:
+        return jsonify({'error': 'word_id is required'}), 400
+
+    word = Word.query.get(word_id)
+    if not word:
+        return jsonify({'error': 'Word not found'}), 404
+
+    progress = UserWordProgress.query.filter_by(
+        user_id=current_user.id,
+        word_id=word_id
+    ).first()
+
+    if progress:
+        progress.status = 'mastered'
+        progress.updated_at = datetime.now(timezone.utc)
+    else:
+        progress = UserWordProgress(
+            user_id=current_user.id,
+            word_id=word_id,
+            status='mastered',
+            assigned_date=date_type.today()
+        )
+        db.session.add(progress)
+
+    db.session.commit()
+    return jsonify(progress.to_dict()), 200
+
+
+@daily_learning_bp.route('/daily-learning/add-to-bank', methods=['POST'])
+@login_required
+def add_word_to_bank():
+    """Add a word to the user's word bank from learning context."""
+    data = request.get_json()
+    word_id = data.get('word_id')
+
+    if not word_id:
+        return jsonify({'error': 'word_id is required'}), 400
+
+    word = Word.query.get(word_id)
+    if not word:
+        return jsonify({'error': 'Word not found'}), 404
+
+    existing = WordBank.query.filter_by(
+        user_id=current_user.id,
+        word_id=word_id
+    ).first()
+    if existing:
+        return jsonify({'error': 'Word already in bank'}), 409
+
+    entry = WordBank(user_id=current_user.id, word_id=word_id)
+    db.session.add(entry)
+    db.session.commit()
+
+    return jsonify(entry.to_dict()), 201

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -20,20 +20,23 @@ export const authAPI = {
   me: () => api.get('/auth/me'),
 };
 
-// Daily Words APIs
+// Daily Words APIs (legacy)
 export const dailyWordsAPI = {
   getWords: (date) => api.get('/daily-words', { params: { date } }),
 };
 
-// Export getDailyWords function for DailyWords component
-export const getDailyWords = async (date) => {
-  try {
-    const response = await dailyWordsAPI.getWords(date);
-    return response;
-  } catch (error) {
-    console.error('Error in getDailyWords:', error);
-    throw error;
-  }
+// Daily Learning APIs
+export const dailyLearningAPI = {
+  getToday: (count) => api.get('/daily-learning/today', { params: { count } }),
+  updateWordStatus: (progressId, status) =>
+    api.post('/daily-learning/word-status', { progress_id: progressId, status }),
+  getReviewWords: () => api.get('/daily-learning/review-words'),
+  getMasteredWords: () => api.get('/daily-learning/mastered-words'),
+  getAllWords: (page, perPage, search) =>
+    api.get('/daily-learning/all-words', { params: { page, per_page: perPage, search } }),
+  getStats: () => api.get('/daily-learning/stats'),
+  markMastered: (wordId) => api.post('/daily-learning/mark-mastered', { word_id: wordId }),
+  addToBank: (wordId) => api.post('/daily-learning/add-to-bank', { word_id: wordId }),
 };
 
 // Word Bank APIs
@@ -41,9 +44,9 @@ export const wordBankAPI = {
   getAll: () => api.get('/word-bank'),
   add: (wordData) => api.post('/word-bank', wordData),
   remove: (entryId) => api.delete(`/word-bank/${entryId}`),
-  updateMastery: (entryId, level) => 
+  updateMastery: (entryId, level) =>
    api.patch(`/word-bank/${entryId}`, { mastery_level: level }),
-  review: (entryId, knewIt) => 
+  review: (entryId, knewIt) =>
    api.post(`/word-bank/${entryId}/review`, { knew_it: knewIt }),
   getStats: () => api.get('/word-bank/stats'),
 };

--- a/frontend/src/pages/DailyWords.jsx
+++ b/frontend/src/pages/DailyWords.jsx
@@ -1,55 +1,114 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Typography, Card, Tag, Button, App, Tooltip, Badge, Spin, Modal, InputNumber, Table } from 'antd';
-import { SoundOutlined, PlusOutlined, CheckOutlined, CalendarOutlined, BookOutlined, SettingOutlined } from '@ant-design/icons';
-import { wordBankAPI } from '../api';
-import { parseAWL, getDailyWords } from '../utils/awlUtils';
+import {
+  Typography, Card, Tag, Button, App, Tooltip, Spin, Modal, InputNumber,
+  Empty, Progress, Divider, List, Space, Input
+} from 'antd';
+import {
+  SoundOutlined, PlusOutlined, CheckOutlined, CalendarOutlined,
+  BookOutlined, SettingOutlined, PlayCircleOutlined, EyeOutlined,
+  ReloadOutlined, TrophyOutlined, SearchOutlined, StarOutlined
+} from '@ant-design/icons';
+import { dailyLearningAPI, wordBankAPI } from '../api';
 
 const { Title, Text, Paragraph } = Typography;
 
 const DAILY_COUNT_KEY = 'dailyWordsCount';
-const DEFAULT_COUNT = 8;
+const DEFAULT_COUNT = 10;
 
 export default function DailyWords() {
-  const [words, setWords] = useState([]);
-  const [allWords, setAllWords] = useState([]);
+  // Main state
+  const [todayWords, setTodayWords] = useState([]);
+  const [reviewCount, setReviewCount] = useState(0);
+  const [masteredCount, setMasteredCount] = useState(0);
+  const [totalWords, setTotalWords] = useState(0);
   const [date, setDate] = useState('');
-  const [savedIds, setSavedIds] = useState(new Set());
   const [loading, setLoading] = useState(true);
-  const [allWordsModalOpen, setAllWordsModalOpen] = useState(false);
-  const [settingsModalOpen, setSettingsModalOpen] = useState(false);
+  const [bankIds, setBankIds] = useState(new Set());
+
+  // Settings
   const [dailyCount, setDailyCount] = useState(() => {
     const saved = localStorage.getItem(DAILY_COUNT_KEY);
     return saved ? parseInt(saved, 10) : DEFAULT_COUNT;
   });
-  const [tempCount, setTempCount] = useState(dailyCount);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [tempCount, setTempCount] = useState(DEFAULT_COUNT);
+
+  // Learning modal state
+  const [learningOpen, setLearningOpen] = useState(false);
+  const [learningWords, setLearningWords] = useState([]);
+  const [learningIndex, setLearningIndex] = useState(0);
+  const [showDef, setShowDef] = useState(false);
+
+  // Review modal state
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [reviewWords, setReviewWords] = useState([]);
+  const [reviewIndex, setReviewIndex] = useState(0);
+  const [showReviewDef, setShowReviewDef] = useState(false);
+  const [reviewCountSetting, setReviewCountSetting] = useState(0);
+  const [reviewSettingOpen, setReviewSettingOpen] = useState(false);
+  const [tempReviewCount, setTempReviewCount] = useState(10);
+
+  // Preview modal
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  // All words modal
+  const [allWordsOpen, setAllWordsOpen] = useState(false);
+  const [allWords, setAllWords] = useState([]);
+  const [allWordsTotal, setAllWordsTotal] = useState(0);
+  const [allWordsPage, setAllWordsPage] = useState(1);
+  const [allWordsSearch, setAllWordsSearch] = useState('');
+  const [allWordsLoading, setAllWordsLoading] = useState(false);
+
+  // Review words list modal
+  const [reviewListOpen, setReviewListOpen] = useState(false);
+  const [reviewListWords, setReviewListWords] = useState([]);
+  const [reviewListLoading, setReviewListLoading] = useState(false);
+
+  // Mastered words modal
+  const [masteredOpen, setMasteredOpen] = useState(false);
+  const [masteredWords, setMasteredWords] = useState([]);
+  const [masteredLoading, setMasteredLoading] = useState(false);
+
   const { message } = App.useApp();
 
-  const refreshDailyWords = useCallback((all, count) => {
-    const today = new Date();
-    setWords(getDailyWords(all, today, count));
-    setDate(today.toISOString().split('T')[0]);
-  }, []);
+  // Load today's data
+  const loadToday = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await dailyLearningAPI.getToday(dailyCount);
+      const data = res.data;
+      setTodayWords(data.words || []);
+      setReviewCount(data.review_count || 0);
+      setMasteredCount(data.mastered_count || 0);
+      setTotalWords(data.total_words || 0);
+      setDate(data.date || '');
+    } catch (error) {
+      console.error('Error loading today:', error);
+      message.error('Failed to load daily words');
+    } finally {
+      setLoading(false);
+    }
+  }, [dailyCount, message]);
 
   useEffect(() => {
-    const fetchDailyWords = async () => {
+    loadToday();
+  }, [loadToday]);
+
+  // Load existing word bank IDs on mount so "Add to Bank" buttons show correct state
+  useEffect(() => {
+    const loadBankIds = async () => {
       try {
-        setLoading(true);
-        const parsed = await parseAWL();
-        setAllWords(parsed);
-        refreshDailyWords(parsed, dailyCount);
+        const res = await wordBankAPI.getAll();
+        const ids = new Set((res.data.words || []).map(w => w.word_id));
+        setBankIds(ids);
       } catch (error) {
-        console.error('Error loading AWL words:', error);
-        message.error('Failed to load daily words');
-        setWords([]);
-        setDate('');
-      } finally {
-        setLoading(false);
+        console.error('Failed to load bank IDs:', error);
       }
     };
+    loadBankIds();
+  }, []);
 
-    fetchDailyWords();
-  }, [message, dailyCount, refreshDailyWords]);
-
+  // Speech
   const speakWord = (text) => {
     if ('speechSynthesis' in window) {
       window.speechSynthesis.cancel();
@@ -60,207 +119,855 @@ export default function DailyWords() {
     }
   };
 
-  const addToBank = async (word) => {
+  // Settings
+  const handleSaveSettings = () => {
+    const clamped = Math.max(1, Math.min(tempCount || DEFAULT_COUNT, 50));
+    setDailyCount(clamped);
+    localStorage.setItem(DAILY_COUNT_KEY, String(clamped));
+    setSettingsOpen(false);
+    message.success(`Daily words count set to ${clamped}`);
+  };
+
+  // Update word status
+  const updateStatus = async (progressId, status) => {
     try {
-      await wordBankAPI.add({
-        word_text: word.text,
-        definition: word.definition,
-        part_of_speech: word.part_of_speech,
-        difficulty_level: word.difficulty_level,
-        example_sentence: word.example_sentence,
-      });
-      setSavedIds((prev) => new Set([...prev, word.text]));
-      message.success('Word added to your bank!');
+      await dailyLearningAPI.updateWordStatus(progressId, status);
+      return true;
     } catch (error) {
-      console.error('Error adding word to bank:', error);
-      if (error.response && error.response.status === 409) {
-        message.error('Word already in your bank');
+      console.error('Error updating status:', error);
+      message.error('Failed to update word status');
+      return false;
+    }
+  };
+
+  // Add to bank
+  const addToBank = async (wordId) => {
+    try {
+      await dailyLearningAPI.addToBank(wordId);
+      setBankIds(prev => new Set([...prev, wordId]));
+      message.success('Added to Word Bank!');
+    } catch (error) {
+      if (error.response?.status === 409) {
+        message.info('Already in Word Bank');
+        setBankIds(prev => new Set([...prev, wordId]));
       } else {
-        message.error('Failed to add word to bank');
+        message.error('Failed to add to bank');
       }
     }
   };
 
-  const handleSaveSettings = () => {
-    const clamped = Math.max(1, Math.min(tempCount || DEFAULT_COUNT, allWords.length || 50));
-    setDailyCount(clamped);
-    localStorage.setItem(DAILY_COUNT_KEY, String(clamped));
-    setSettingsModalOpen(false);
-    message.success(`Daily words count set to ${clamped}`);
+  // ==================== Learning Session ====================
+  const startLearning = () => {
+    if (todayWords.length === 0) {
+      message.info('No words to learn today!');
+      return;
+    }
+    setLearningWords([...todayWords]);
+    setLearningIndex(0);
+    setShowDef(false);
+    setLearningOpen(true);
   };
 
-  const difficultyColor = {
-    beginner: 'green',
-    intermediate: 'blue',
-    advanced: 'orange',
+  const handleLearningAction = async (action) => {
+    const word = learningWords[learningIndex];
+    if (!word) return;
+
+    if (action === 'mastered') {
+      await updateStatus(word.id, 'mastered');
+    } else if (action === 'review') {
+      await updateStatus(word.id, 'review');
+    }
+
+    // Move to next word
+    if (learningIndex < learningWords.length - 1) {
+      setLearningIndex(prev => prev + 1);
+      setShowDef(false);
+    } else {
+      setLearningOpen(false);
+      message.success('Learning session complete!');
+      loadToday();
+    }
   };
 
-  const allWordsColumns = [
-    {
-      title: '#',
-      dataIndex: 'id',
-      key: 'id',
-      width: 60,
-    },
-    {
-      title: 'Word',
-      dataIndex: 'text',
-      key: 'text',
-      width: 160,
-      render: (text) => <Text strong>{text}</Text>,
-    },
-    {
-      title: 'Definition',
-      dataIndex: 'definition',
-      key: 'definition',
-    },
-  ];
+  // ==================== Review Session ====================
+  const openReviewSettings = async () => {
+    try {
+      setReviewListLoading(true);
+      const res = await dailyLearningAPI.getReviewWords();
+      const words = res.data.words || [];
+      setReviewListWords(words);
+      setTempReviewCount(Math.min(10, words.length));
+      setReviewSettingOpen(true);
+    } catch (error) {
+      message.error('Failed to load review words');
+    } finally {
+      setReviewListLoading(false);
+    }
+  };
+
+  const startReview = () => {
+    const count = Math.min(tempReviewCount, reviewListWords.length);
+    if (count === 0) {
+      message.info('No words to review!');
+      return;
+    }
+    setReviewWords(reviewListWords.slice(0, count));
+    setReviewIndex(0);
+    setShowReviewDef(false);
+    setReviewSettingOpen(false);
+    setReviewOpen(true);
+  };
+
+  const handleReviewAction = async (action) => {
+    const word = reviewWords[reviewIndex];
+    if (!word) return;
+
+    if (action === 'mastered') {
+      await updateStatus(word.id, 'mastered');
+    }
+    // 'still_review' means keep status as review, no API call needed
+
+    if (reviewIndex < reviewWords.length - 1) {
+      setReviewIndex(prev => prev + 1);
+      setShowReviewDef(false);
+    } else {
+      setReviewOpen(false);
+      message.success('Review session complete!');
+      loadToday();
+    }
+  };
+
+  // ==================== All Words ====================
+  const loadAllWords = async (page = 1, search = '') => {
+    try {
+      setAllWordsLoading(true);
+      const res = await dailyLearningAPI.getAllWords(page, 50, search);
+      setAllWords(res.data.words || []);
+      setAllWordsTotal(res.data.total || 0);
+      setAllWordsPage(page);
+    } catch (error) {
+      message.error('Failed to load words');
+    } finally {
+      setAllWordsLoading(false);
+    }
+  };
+
+  const openAllWords = () => {
+    setAllWordsSearch('');
+    loadAllWords(1, '');
+    setAllWordsOpen(true);
+  };
+
+  const markMasteredByWordId = async (wordId) => {
+    try {
+      await dailyLearningAPI.markMastered(wordId);
+      message.success('Marked as mastered');
+      // Update local state
+      setAllWords(prev => prev.map(w =>
+        w.id === wordId ? { ...w, progress_status: 'mastered' } : w
+      ));
+      setMasteredCount(prev => prev + 1);
+      // Also remove from today's words if it was there
+      setTodayWords(prev => prev.filter(w => w.word_id !== wordId));
+    } catch (error) {
+      message.error('Failed to mark as mastered');
+    }
+  };
+
+  // ==================== Review Words List ====================
+  const openReviewList = async () => {
+    try {
+      setReviewListLoading(true);
+      const res = await dailyLearningAPI.getReviewWords();
+      setReviewListWords(res.data.words || []);
+      setReviewListOpen(true);
+    } catch (error) {
+      message.error('Failed to load review words');
+    } finally {
+      setReviewListLoading(false);
+    }
+  };
+
+  const markReviewAsMastered = async (progressId) => {
+    const ok = await updateStatus(progressId, 'mastered');
+    if (ok) {
+      setReviewListWords(prev => prev.filter(w => w.id !== progressId));
+      setReviewCount(prev => prev - 1);
+      setMasteredCount(prev => prev + 1);
+    }
+  };
+
+  // ==================== Mastered Words ====================
+  const openMastered = async () => {
+    try {
+      setMasteredLoading(true);
+      const res = await dailyLearningAPI.getMasteredWords();
+      setMasteredWords(res.data.words || []);
+      setMasteredOpen(true);
+    } catch (error) {
+      message.error('Failed to load mastered words');
+    } finally {
+      setMasteredLoading(false);
+    }
+  };
+
+  // ==================== Preview ====================
+  const handlePreviewMastered = async (progressId) => {
+    const ok = await updateStatus(progressId, 'mastered');
+    if (ok) {
+      setTodayWords(prev => prev.filter(w => w.id !== progressId));
+      message.success('Marked as mastered');
+    }
+  };
+
+  // ==================== Render ====================
+  const currentLearningWord = learningWords[learningIndex];
+  const currentReviewWord = reviewWords[reviewIndex];
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <div className="page-container" style={{ padding: '24px' }}>
+      {/* Header */}
+      <div style={{ marginBottom: 24 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}>
           <div>
             <Title level={2} style={{ margin: 0, fontWeight: 700, color: '#1a1a2e' }}>Daily Words</Title>
             <Text type="secondary" style={{ fontSize: 14 }}>
               <CalendarOutlined style={{ marginRight: 6 }} />{date}
             </Text>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Tooltip title="View All Words">
-              <Button
-                icon={<BookOutlined />}
-                onClick={() => setAllWordsModalOpen(true)}
-              >
-                All Words ({allWords.length})
-              </Button>
-            </Tooltip>
-            <Tooltip title="Settings">
-              <Button
-                icon={<SettingOutlined />}
-                onClick={() => { setTempCount(dailyCount); setSettingsModalOpen(true); }}
-              >
-                {dailyCount}/day
-              </Button>
-            </Tooltip>
-            <Badge count={(words || []).length} style={{ backgroundColor: '#2563eb' }}>
-              <Tag color="blue" style={{ fontSize: 14, padding: '4px 12px', borderRadius: 20 }}>
-                Today&apos;s Words
-              </Tag>
-            </Badge>
-          </div>
+          <Button
+            icon={<SettingOutlined />}
+            onClick={() => { setTempCount(dailyCount); setSettingsOpen(true); }}
+          >
+            {dailyCount} words/day
+          </Button>
         </div>
       </div>
 
-      <Spin spinning={loading} tip="Loading daily words...">
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {(words || []).map((word, index) => (
-            <Card
-              key={word.text}
-              style={{
-                borderRadius: 12,
-                border: '1px solid #e5e7eb',
-                transition: 'all 0.2s',
-              }}
-              styles={{ body: { padding: '20px 24px' } }}
-              hoverable
-            >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
-                    <span style={{
-                      width: 28,
-                      height: 28,
-                      borderRadius: 8,
-                      background: '#eff6ff',
-                      color: '#2563eb',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 13,
-                      fontWeight: 700,
-                    }}>
-                      {index + 1}
-                    </span>
-                    <Title level={4} style={{ margin: 0, fontWeight: 600 }}>{word.text}</Title>
-                    {word.part_of_speech && (
-                      <Tag style={{ borderRadius: 12 }}>{word.part_of_speech}</Tag>
-                    )}
-                    <Tag color={difficultyColor[word.difficulty_level]} style={{ borderRadius: 12 }}>
-                      {word.difficulty_level}
-                    </Tag>
-                  </div>
-                  <Paragraph style={{ margin: '0 0 6px', paddingLeft: 40, color: '#374151', fontSize: 14 }}>
-                    {word.definition}
-                  </Paragraph>
-                  {word.example_sentence && (
-                    <Text italic style={{ paddingLeft: 40, color: '#6b7280', fontSize: 13 }}>
-                      &ldquo;{word.example_sentence}&rdquo;
-                    </Text>
-                  )}
-                </div>
-                <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
-                  <Tooltip title="Listen">
-                    <Button
-                      shape="circle"
-                      icon={<SoundOutlined />}
-                      onClick={() => speakWord(word.text)}
-                      style={{ color: '#2563eb', borderColor: '#93c5fd' }}
-                    />
-                  </Tooltip>
-                  <Tooltip title={savedIds.has(word.text) ? 'Saved' : 'Save to bank'}>
-                    <Button
-                      shape="circle"
-                      type={savedIds.has(word.text) ? 'primary' : 'default'}
-                      icon={savedIds.has(word.text) ? <CheckOutlined /> : <PlusOutlined />}
-                      onClick={() => addToBank(word)}
-                      disabled={savedIds.has(word.text)}
-                      style={!savedIds.has(word.text) ? { color: '#059669', borderColor: '#6ee7b7' } : {}}
-                    />
-                  </Tooltip>
-                </div>
-              </div>
-            </Card>
-          ))}
+      <Spin spinning={loading}>
+        {/* Main Action Cards */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16, marginBottom: 24 }}>
+          {/* Start Learning Card */}
+          <Card
+            hoverable
+            style={{
+              borderRadius: 16,
+              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+            styles={{ body: { padding: '28px 24px' } }}
+            onClick={startLearning}
+          >
+            <div style={{ color: '#fff' }}>
+              <PlayCircleOutlined style={{ fontSize: 36, marginBottom: 12, display: 'block' }} />
+              <Title level={3} style={{ color: '#fff', margin: '0 0 8px' }}>Start Learning</Title>
+              <Text style={{ color: 'rgba(255,255,255,0.85)', fontSize: 15 }}>
+                {todayWords.length} words to learn today
+              </Text>
+              <Progress
+                percent={todayWords.length === 0 ? 100 : 0}
+                strokeColor="rgba(255,255,255,0.5)"
+                trailColor="rgba(255,255,255,0.15)"
+                showInfo={false}
+                style={{ marginTop: 12 }}
+              />
+            </div>
+          </Card>
+
+          {/* Start Review Card */}
+          <Card
+            hoverable
+            style={{
+              borderRadius: 16,
+              background: 'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+            styles={{ body: { padding: '28px 24px' } }}
+            onClick={openReviewSettings}
+          >
+            <div style={{ color: '#fff' }}>
+              <ReloadOutlined style={{ fontSize: 36, marginBottom: 12, display: 'block' }} />
+              <Title level={3} style={{ color: '#fff', margin: '0 0 8px' }}>Start Review</Title>
+              <Text style={{ color: 'rgba(255,255,255,0.85)', fontSize: 15 }}>
+                {reviewCount} words to review
+              </Text>
+            </div>
+          </Card>
+
+          {/* Mastered Card */}
+          <Card
+            hoverable
+            style={{
+              borderRadius: 16,
+              background: 'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+              border: 'none',
+              cursor: 'pointer',
+            }}
+            styles={{ body: { padding: '28px 24px' } }}
+            onClick={openMastered}
+          >
+            <div style={{ color: '#fff' }}>
+              <TrophyOutlined style={{ fontSize: 36, marginBottom: 12, display: 'block' }} />
+              <Title level={3} style={{ color: '#fff', margin: '0 0 8px' }}>Mastered</Title>
+              <Text style={{ color: 'rgba(255,255,255,0.85)', fontSize: 15 }}>
+                {masteredCount} words mastered
+              </Text>
+            </div>
+          </Card>
         </div>
+
+        {/* Quick Actions */}
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
+          <Button icon={<EyeOutlined />} onClick={() => setPreviewOpen(true)} disabled={todayWords.length === 0}>
+            Preview Today&apos;s Words
+          </Button>
+          <Button icon={<BookOutlined />} onClick={openAllWords}>
+            View All Words ({totalWords})
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={openReviewList}>
+            View Review Words ({reviewCount})
+          </Button>
+        </div>
+
+        {/* Stats Bar */}
+        <Card style={{ borderRadius: 12, marginBottom: 24 }} styles={{ body: { padding: '16px 24px' } }}>
+          <div style={{ display: 'flex', justifyContent: 'space-around', textAlign: 'center', flexWrap: 'wrap', gap: 16 }}>
+            <div>
+              <Text type="secondary" style={{ fontSize: 12 }}>Today</Text>
+              <div style={{ fontSize: 24, fontWeight: 700, color: '#667eea' }}>{todayWords.length}</div>
+              <Text type="secondary" style={{ fontSize: 12 }}>to learn</Text>
+            </div>
+            <Divider type="vertical" style={{ height: 60 }} />
+            <div>
+              <Text type="secondary" style={{ fontSize: 12 }}>Review</Text>
+              <div style={{ fontSize: 24, fontWeight: 700, color: '#f5576c' }}>{reviewCount}</div>
+              <Text type="secondary" style={{ fontSize: 12 }}>pending</Text>
+            </div>
+            <Divider type="vertical" style={{ height: 60 }} />
+            <div>
+              <Text type="secondary" style={{ fontSize: 12 }}>Mastered</Text>
+              <div style={{ fontSize: 24, fontWeight: 700, color: '#00c9a7' }}>{masteredCount}</div>
+              <Text type="secondary" style={{ fontSize: 12 }}>words</Text>
+            </div>
+            <Divider type="vertical" style={{ height: 60 }} />
+            <div>
+              <Text type="secondary" style={{ fontSize: 12 }}>Total Pool</Text>
+              <div style={{ fontSize: 24, fontWeight: 700, color: '#6c757d' }}>{totalWords}</div>
+              <Text type="secondary" style={{ fontSize: 12 }}>words</Text>
+            </div>
+          </div>
+        </Card>
       </Spin>
 
+      {/* ==================== Learning Modal ==================== */}
       <Modal
-        title={`All AWL Words (${allWords.length})`}
-        open={allWordsModalOpen}
-        onCancel={() => setAllWordsModalOpen(false)}
+        title={null}
+        open={learningOpen}
+        onCancel={() => { setLearningOpen(false); loadToday(); }}
+        footer={null}
+        width={640}
+        centered
+        closable
+        styles={{ body: { padding: '24px' } }}
+      >
+        {currentLearningWord && (
+          <div>
+            {/* Progress */}
+            <div style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <Text type="secondary">Learning Progress</Text>
+                <Text strong>{learningIndex + 1} / {learningWords.length}</Text>
+              </div>
+              <Progress
+                percent={Math.round(((learningIndex + 1) / learningWords.length) * 100)}
+                showInfo={false}
+                strokeColor={{ from: '#667eea', to: '#764ba2' }}
+              />
+            </div>
+
+            {/* Word Display */}
+            <div style={{ textAlign: 'center', minHeight: 220, padding: '20px 0' }}>
+              <div style={{ marginBottom: 8 }}>
+                <Title level={1} style={{ margin: 0, color: '#1a1a2e', fontSize: 36 }}>
+                  {currentLearningWord.text}
+                </Title>
+                <Button
+                  type="text"
+                  icon={<SoundOutlined />}
+                  onClick={() => speakWord(currentLearningWord.text)}
+                  style={{ color: '#667eea', marginTop: 4 }}
+                >
+                  Listen
+                </Button>
+              </div>
+
+              {currentLearningWord.part_of_speech && (
+                <Tag style={{ marginBottom: 12 }}>{currentLearningWord.part_of_speech}</Tag>
+              )}
+
+              {showDef ? (
+                <div style={{
+                  textAlign: 'left',
+                  background: '#f8f9fa',
+                  padding: 20,
+                  borderRadius: 12,
+                  marginTop: 16,
+                }}>
+                  <Text strong style={{ color: '#667eea' }}>Definition:</Text>
+                  <Paragraph style={{ margin: '8px 0', fontSize: 15 }}>
+                    {currentLearningWord.definition}
+                  </Paragraph>
+                  {currentLearningWord.example_sentence && (
+                    <>
+                      <Divider style={{ margin: '12px 0' }} />
+                      <Text strong style={{ color: '#667eea' }}>Example:</Text>
+                      <Paragraph italic style={{ margin: '8px 0', color: '#6b7280' }}>
+                        &ldquo;{currentLearningWord.example_sentence}&rdquo;
+                      </Paragraph>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <Button
+                  type="dashed"
+                  size="large"
+                  onClick={() => setShowDef(true)}
+                  style={{ marginTop: 16 }}
+                >
+                  Show Definition
+                </Button>
+              )}
+            </div>
+
+            {/* Action Buttons */}
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'center', marginTop: 20, flexWrap: 'wrap' }}>
+              <Button
+                size="large"
+                type="primary"
+                style={{ background: '#059669', borderColor: '#059669', minWidth: 140 }}
+                icon={<CheckOutlined />}
+                onClick={() => handleLearningAction('mastered')}
+              >
+                I&apos;ve Mastered
+              </Button>
+              <Button
+                size="large"
+                icon={<ReloadOutlined />}
+                onClick={() => handleLearningAction('review')}
+                style={{ minWidth: 140 }}
+              >
+                Review Later
+              </Button>
+              <Tooltip title={bankIds.has(currentLearningWord.word_id) ? 'Already in bank' : 'Add to Word Bank'}>
+                <Button
+                  size="large"
+                  icon={bankIds.has(currentLearningWord.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={bankIds.has(currentLearningWord.word_id)}
+                  onClick={() => addToBank(currentLearningWord.word_id)}
+                  style={{ minWidth: 140 }}
+                >
+                  {bankIds.has(currentLearningWord.word_id) ? 'In Bank' : 'Add to Bank'}
+                </Button>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* ==================== Review Settings Modal ==================== */}
+      <Modal
+        title="Review Settings"
+        open={reviewSettingOpen}
+        onCancel={() => setReviewSettingOpen(false)}
+        onOk={startReview}
+        okText="Start Review"
+        okButtonProps={{ disabled: reviewListWords.length === 0 }}
+      >
+        <div style={{ padding: '16px 0' }}>
+          {reviewListWords.length === 0 ? (
+            <Empty description="No words to review" />
+          ) : (
+            <>
+              <Text>Total review words: <Text strong>{reviewListWords.length}</Text></Text>
+              <div style={{ marginTop: 16 }}>
+                <Text>How many words to review today:</Text>
+                <div style={{ marginTop: 8 }}>
+                  <InputNumber
+                    min={1}
+                    max={reviewListWords.length}
+                    value={tempReviewCount}
+                    onChange={(val) => setTempReviewCount(val)}
+                    style={{ width: 120 }}
+                  />
+                  <Text type="secondary" style={{ marginLeft: 12 }}>
+                    (1 - {reviewListWords.length})
+                  </Text>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </Modal>
+
+      {/* ==================== Review Session Modal ==================== */}
+      <Modal
+        title={null}
+        open={reviewOpen}
+        onCancel={() => { setReviewOpen(false); loadToday(); }}
+        footer={null}
+        width={640}
+        centered
+        closable
+        styles={{ body: { padding: '24px' } }}
+      >
+        {currentReviewWord && (
+          <div>
+            {/* Progress */}
+            <div style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <Text type="secondary">Review Progress</Text>
+                <Text strong>{reviewIndex + 1} / {reviewWords.length}</Text>
+              </div>
+              <Progress
+                percent={Math.round(((reviewIndex + 1) / reviewWords.length) * 100)}
+                showInfo={false}
+                strokeColor={{ from: '#f093fb', to: '#f5576c' }}
+              />
+            </div>
+
+            {/* Word Display */}
+            <div style={{ textAlign: 'center', minHeight: 220, padding: '20px 0' }}>
+              <div style={{ marginBottom: 8 }}>
+                <Title level={1} style={{ margin: 0, color: '#1a1a2e', fontSize: 36 }}>
+                  {currentReviewWord.text}
+                </Title>
+                <Button
+                  type="text"
+                  icon={<SoundOutlined />}
+                  onClick={() => speakWord(currentReviewWord.text)}
+                  style={{ color: '#f5576c', marginTop: 4 }}
+                >
+                  Listen
+                </Button>
+              </div>
+
+              {showReviewDef ? (
+                <div style={{
+                  textAlign: 'left',
+                  background: '#fef2f2',
+                  padding: 20,
+                  borderRadius: 12,
+                  marginTop: 16,
+                }}>
+                  <Text strong style={{ color: '#f5576c' }}>Definition:</Text>
+                  <Paragraph style={{ margin: '8px 0', fontSize: 15 }}>
+                    {currentReviewWord.definition}
+                  </Paragraph>
+                  {currentReviewWord.example_sentence && (
+                    <>
+                      <Divider style={{ margin: '12px 0' }} />
+                      <Text strong style={{ color: '#f5576c' }}>Example:</Text>
+                      <Paragraph italic style={{ margin: '8px 0', color: '#6b7280' }}>
+                        &ldquo;{currentReviewWord.example_sentence}&rdquo;
+                      </Paragraph>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <Button
+                  type="dashed"
+                  size="large"
+                  onClick={() => setShowReviewDef(true)}
+                  style={{ marginTop: 16 }}
+                >
+                  Show Definition
+                </Button>
+              )}
+            </div>
+
+            {/* Action Buttons */}
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'center', marginTop: 20, flexWrap: 'wrap' }}>
+              <Button
+                size="large"
+                type="primary"
+                style={{ background: '#059669', borderColor: '#059669', minWidth: 140 }}
+                icon={<CheckOutlined />}
+                onClick={() => handleReviewAction('mastered')}
+              >
+                I&apos;ve Mastered
+              </Button>
+              <Button
+                size="large"
+                icon={<ReloadOutlined />}
+                onClick={() => handleReviewAction('still_review')}
+                style={{ minWidth: 140 }}
+              >
+                Still Need Review
+              </Button>
+              <Tooltip title={bankIds.has(currentReviewWord.word_id) ? 'Already in bank' : 'Add to Word Bank'}>
+                <Button
+                  size="large"
+                  icon={bankIds.has(currentReviewWord.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={bankIds.has(currentReviewWord.word_id)}
+                  onClick={() => addToBank(currentReviewWord.word_id)}
+                  style={{ minWidth: 140 }}
+                >
+                  {bankIds.has(currentReviewWord.word_id) ? 'In Bank' : 'Add to Bank'}
+                </Button>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* ==================== Preview Today's Words Modal ==================== */}
+      <Modal
+        title={`Today's Words (${todayWords.length})`}
+        open={previewOpen}
+        onCancel={() => setPreviewOpen(false)}
         footer={null}
         width={700}
       >
-        <Table
-          dataSource={allWords}
-          columns={allWordsColumns}
-          rowKey="id"
-          size="small"
-          pagination={{ pageSize: 20, showSizeChanger: true, pageSizeOptions: ['20', '50', '100'] }}
-          scroll={{ y: 500 }}
+        <List
+          dataSource={todayWords}
+          renderItem={(word) => (
+            <List.Item
+              actions={[
+                <Button
+                  key="sound"
+                  type="text"
+                  icon={<SoundOutlined />}
+                  onClick={() => speakWord(word.text)}
+                />,
+                <Button
+                  key="bank"
+                  type="text"
+                  icon={bankIds.has(word.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={bankIds.has(word.word_id)}
+                  onClick={() => addToBank(word.word_id)}
+                >
+                  {bankIds.has(word.word_id) ? 'In Bank' : 'Add'}
+                </Button>,
+                <Button
+                  key="mastered"
+                  type="text"
+                  icon={<StarOutlined />}
+                  onClick={() => handlePreviewMastered(word.id)}
+                  style={{ color: '#059669' }}
+                >
+                  Mastered
+                </Button>,
+              ]}
+            >
+              <List.Item.Meta
+                title={<Text strong style={{ fontSize: 16 }}>{word.text}</Text>}
+                description={word.definition}
+              />
+            </List.Item>
+          )}
+          locale={{ emptyText: <Empty description="No words for today" /> }}
         />
       </Modal>
 
+      {/* ==================== All Words Modal ==================== */}
+      <Modal
+        title={`All Words (${allWordsTotal})`}
+        open={allWordsOpen}
+        onCancel={() => setAllWordsOpen(false)}
+        footer={null}
+        width={750}
+      >
+        <Input
+          placeholder="Search words..."
+          prefix={<SearchOutlined />}
+          value={allWordsSearch}
+          onChange={(e) => {
+            setAllWordsSearch(e.target.value);
+            loadAllWords(1, e.target.value);
+          }}
+          allowClear
+          style={{ marginBottom: 16 }}
+        />
+        <Spin spinning={allWordsLoading}>
+          <List
+            dataSource={allWords}
+            pagination={{
+              current: allWordsPage,
+              total: allWordsTotal,
+              pageSize: 50,
+              onChange: (page) => loadAllWords(page, allWordsSearch),
+              size: 'small',
+            }}
+            renderItem={(word) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="bank"
+                    type="text"
+                    icon={word.in_word_bank ? <CheckOutlined /> : <PlusOutlined />}
+                    disabled={word.in_word_bank}
+                    onClick={() => addToBank(word.id)}
+                    size="small"
+                  >
+                    {word.in_word_bank ? 'In Bank' : 'Add to Bank'}
+                  </Button>,
+                  word.progress_status === 'mastered' ? (
+                    <Tag key="status" color="green">mastered</Tag>
+                  ) : (
+                    <Button
+                      key="mastered"
+                      type="text"
+                      icon={<StarOutlined />}
+                      onClick={() => markMasteredByWordId(word.id)}
+                      size="small"
+                      style={{ color: '#059669' }}
+                    >
+                      Mastered
+                    </Button>
+                  ),
+                  word.progress_status && word.progress_status !== 'mastered' && (
+                    <Tag key="status" color={
+                      word.progress_status === 'review' ? 'orange' : 'blue'
+                    }>
+                      {word.progress_status}
+                    </Tag>
+                  ),
+                ].filter(Boolean)}
+              >
+                <List.Item.Meta
+                  title={
+                    <Space>
+                      <Text strong>{word.text}</Text>
+                      <Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} />
+                    </Space>
+                  }
+                  description={word.definition}
+                />
+              </List.Item>
+            )}
+          />
+        </Spin>
+      </Modal>
+
+      {/* ==================== Review Words List Modal ==================== */}
+      <Modal
+        title={`Review Words (${reviewListWords.length})`}
+        open={reviewListOpen}
+        onCancel={() => setReviewListOpen(false)}
+        footer={null}
+        width={700}
+      >
+        <Spin spinning={reviewListLoading}>
+          <List
+            dataSource={reviewListWords}
+            renderItem={(word) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="sound"
+                    type="text"
+                    icon={<SoundOutlined />}
+                    onClick={() => speakWord(word.text)}
+                  />,
+                  <Button
+                    key="bank"
+                    type="text"
+                    icon={bankIds.has(word.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                    disabled={bankIds.has(word.word_id)}
+                    onClick={() => addToBank(word.word_id)}
+                  >
+                    {bankIds.has(word.word_id) ? 'In Bank' : 'Add'}
+                  </Button>,
+                  <Button
+                    key="mastered"
+                    type="text"
+                    icon={<StarOutlined />}
+                    onClick={() => markReviewAsMastered(word.id)}
+                    style={{ color: '#059669' }}
+                  >
+                    Mastered
+                  </Button>,
+                ]}
+              >
+                <List.Item.Meta
+                  title={<Text strong style={{ fontSize: 16 }}>{word.text}</Text>}
+                  description={word.definition}
+                />
+              </List.Item>
+            )}
+            locale={{ emptyText: <Empty description="No review words" /> }}
+          />
+        </Spin>
+      </Modal>
+
+      {/* ==================== Mastered Words Modal ==================== */}
+      <Modal
+        title={`Mastered Words (${masteredWords.length})`}
+        open={masteredOpen}
+        onCancel={() => setMasteredOpen(false)}
+        footer={null}
+        width={700}
+      >
+        <Spin spinning={masteredLoading}>
+          <List
+            dataSource={masteredWords}
+            pagination={{ pageSize: 20 }}
+            renderItem={(word) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="sound"
+                    type="text"
+                    icon={<SoundOutlined />}
+                    onClick={() => speakWord(word.text)}
+                  />,
+                  <Button
+                    key="bank"
+                    type="text"
+                    icon={bankIds.has(word.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                    disabled={bankIds.has(word.word_id)}
+                    onClick={() => addToBank(word.word_id)}
+                  >
+                    {bankIds.has(word.word_id) ? 'In Bank' : 'Add to Bank'}
+                  </Button>,
+                ]}
+              >
+                <List.Item.Meta
+                  title={<Text strong style={{ fontSize: 16 }}>{word.text}</Text>}
+                  description={word.definition}
+                />
+              </List.Item>
+            )}
+            locale={{ emptyText: <Empty description="No mastered words yet" /> }}
+          />
+        </Spin>
+      </Modal>
+
+      {/* ==================== Settings Modal ==================== */}
       <Modal
         title="Daily Words Settings"
-        open={settingsModalOpen}
+        open={settingsOpen}
         onOk={handleSaveSettings}
-        onCancel={() => setSettingsModalOpen(false)}
+        onCancel={() => setSettingsOpen(false)}
         okText="Save"
       >
         <div style={{ padding: '16px 0' }}>
-          <Text>Number of words per day:</Text>
+          <Text>Number of new words per day:</Text>
           <div style={{ marginTop: 12 }}>
             <InputNumber
               min={1}
-              max={allWords.length || 50}
+              max={50}
               value={tempCount}
               onChange={(val) => setTempCount(val)}
               style={{ width: 120 }}
             />
-            <Text type="secondary" style={{ marginLeft: 12 }}>
-              (1 - {allWords.length || 50})
+            <Text type="secondary" style={{ marginLeft: 12 }}>(1 - 50)</Text>
+          </div>
+          <div style={{ marginTop: 12 }}>
+            <Text type="secondary">
+              Unfinished words from previous days will carry over automatically.
             </Text>
           </div>
         </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Typography, Card, Row, Col, Progress } from 'antd';
 import {
   ReadOutlined,
@@ -8,6 +9,7 @@ import {
   ArrowRightOutlined,
 } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
+import { dailyLearningAPI } from '../api';
 
 const { Title, Text } = Typography;
 
@@ -24,7 +26,7 @@ const modules = [
     title: 'Word Bank',
     icon: <BookOutlined />,
     path: '/word-bank',
-    desc: 'Review and manage your saved words',
+    desc: 'Manage your saved vocabulary collection',
     color: '#059669',
     bg: 'linear-gradient(135deg, #ecfdf5, #d1fae5)',
   },
@@ -56,6 +58,26 @@ const modules = [
 
 export default function Home() {
   const navigate = useNavigate();
+  const [stats, setStats] = useState({
+    wordsLearned: 0,
+    totalWords: 0,
+  });
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const res = await dailyLearningAPI.getStats();
+        const data = res.data;
+        setStats({
+          wordsLearned: data.total_learned || 0,
+          totalWords: data.total_words || 0,
+        });
+      } catch (error) {
+        console.error('Failed to load stats:', error);
+      }
+    };
+    fetchStats();
+  }, []);
 
   return (
     <div className="page-container">
@@ -75,14 +97,17 @@ export default function Home() {
         </Text>
         <Row gutter={32} style={{ marginTop: 28 }}>
           {[
-            { label: 'Words Learned', value: 0, total: 50 },
+            { label: 'Words Learned', value: stats.wordsLearned, total: Math.max(stats.totalWords, 50) },
             { label: 'Listening Hours', value: 0, total: 10 },
             { label: 'Speaking Sessions', value: 0, total: 20 },
           ].map((s) => (
             <Col span={8} key={s.label}>
               <Text style={{ color: 'rgba(255,255,255,0.5)', fontSize: 12 }}>{s.label}</Text>
+              <div style={{ color: '#fff', fontSize: 16, fontWeight: 600, margin: '4px 0 2px' }}>
+                {s.value} / {s.total}
+              </div>
               <Progress
-                percent={Math.round((s.value / s.total) * 100)}
+                percent={s.total > 0 ? Math.round((s.value / s.total) * 100) : 0}
                 strokeColor={{ from: '#60a5fa', to: '#a78bfa' }}
                 trailColor="rgba(255,255,255,0.15)"
                 size="small"
@@ -109,7 +134,7 @@ export default function Home() {
                 border: 'none',
                 overflow: 'hidden',
               }}
-              bodyStyle={{ padding: 24 }}
+              styles={{ body: { padding: 24 } }}
             >
               <div style={{
                 width: 48,

--- a/frontend/src/pages/WordBank.jsx
+++ b/frontend/src/pages/WordBank.jsx
@@ -1,88 +1,61 @@
-// frontend/src/pages/WordBank.jsx
 import { useState, useEffect } from 'react';
-import { 
-  Typography, 
-  Card, 
-  Button, 
-  Tag, 
-  Empty, 
-  message, 
-  Tooltip, 
-  Input, 
-  Space,
-  Spin,
-  Modal,
-  Select,
-  Row,
-  Col,
-  Statistic,
-  Progress,
-  Divider,
-  Alert
+import {
+  Typography, Card, Button, Tag, Empty, Tooltip, Input, Space, Spin,
+  Modal, Select, List, Progress, Divider, App
 } from 'antd';
-import { 
-  DeleteOutlined, 
-  SoundOutlined, 
-  SearchOutlined, 
-  BookOutlined,
-  ReloadOutlined,
-  BarChartOutlined,
-  ClockCircleOutlined,
-  CheckCircleOutlined,
-  StarOutlined,
-  ExportOutlined,
-  FilterOutlined,
-  SortAscendingOutlined
+import {
+  DeleteOutlined, SoundOutlined, SearchOutlined, BookOutlined,
+  ReloadOutlined, ExportOutlined, SortAscendingOutlined,
+  PlayCircleOutlined, CheckOutlined, PlusOutlined, EyeOutlined,
+  StarOutlined, CloseOutlined
 } from '@ant-design/icons';
-import { wordBankAPI } from '../api';
+import { wordBankAPI, dailyLearningAPI } from '../api';
 
 const { Title, Text, Paragraph } = Typography;
 const { Option } = Select;
 
-// 掌握程度配置
-const masteryConfig = [
-  { label: 'New', color: '#6b7280', bg: '#f3f4f6', value: 0, emoji: '🆕' },
-  { label: 'Learning', color: '#d97706', bg: '#fef3c7', value: 1, emoji: '📚' },
-  { label: 'Familiar', color: '#2563eb', bg: '#dbeafe', value: 2, emoji: '✨' },
-  { label: 'Mastered', color: '#059669', bg: '#d1fae5', value: 3, emoji: '🌟' },
-];
-
-// 排序选项
 const sortOptions = [
   { label: 'Date Added (Newest)', value: 'date_desc' },
   { label: 'Date Added (Oldest)', value: 'date_asc' },
   { label: 'Word (A-Z)', value: 'word_asc' },
   { label: 'Word (Z-A)', value: 'word_desc' },
-  { label: 'Mastery Level', value: 'mastery' },
 ];
 
 export default function WordBank() {
-  // ==================== State Management ====================
   const [words, setWords] = useState([]);
   const [filteredWords, setFilteredWords] = useState([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
-  const [masteryFilter, setMasteryFilter] = useState(null);
   const [sortBy, setSortBy] = useState('date_desc');
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
   const [wordToDelete, setWordToDelete] = useState(null);
-  const [reviewModalVisible, setReviewModalVisible] = useState(false);
-  const [reviewWords, setReviewWords] = useState([]);
-  const [currentReviewIndex, setCurrentReviewIndex] = useState(0);
-  const [showDefinition, setShowDefinition] = useState(false);
-  const [statsModalVisible, setStatsModalVisible] = useState(false);
   const [exportModalVisible, setExportModalVisible] = useState(false);
   const [batchDeleteMode, setBatchDeleteMode] = useState(false);
   const [selectedWords, setSelectedWords] = useState(new Set());
-  const [stats, setStats] = useState({
-    total: 0,
-    new: 0,
-    learning: 0,
-    familiar: 0,
-    mastered: 0,
-    today_reviewed: 0,
-    review_history: []
-  });
+
+  // Learning modal state
+  const [learningOpen, setLearningOpen] = useState(false);
+  const [learningWords, setLearningWords] = useState([]);
+  const [learningIndex, setLearningIndex] = useState(0);
+  const [showDef, setShowDef] = useState(false);
+
+  // All words / review / mastered modal state
+  const [allWordsOpen, setAllWordsOpen] = useState(false);
+  const [allWords, setAllWords] = useState([]);
+  const [allWordsTotal, setAllWordsTotal] = useState(0);
+  const [allWordsPage, setAllWordsPage] = useState(1);
+  const [allWordsSearch, setAllWordsSearch] = useState('');
+  const [allWordsLoading, setAllWordsLoading] = useState(false);
+
+  const [reviewListOpen, setReviewListOpen] = useState(false);
+  const [reviewListWords, setReviewListWords] = useState([]);
+  const [reviewListLoading, setReviewListLoading] = useState(false);
+
+  const [masteredOpen, setMasteredOpen] = useState(false);
+  const [masteredWords, setMasteredWords] = useState([]);
+  const [masteredLoading, setMasteredLoading] = useState(false);
+
+  const { message } = App.useApp();
 
   // ==================== Data Loading ====================
   const loadWordBank = async () => {
@@ -90,9 +63,6 @@ export default function WordBank() {
     try {
       const res = await wordBankAPI.getAll();
       setWords(res.data.words || []);
-      
-      const statsRes = await wordBankAPI.getStats();
-      setStats(statsRes.data);
     } catch (err) {
       message.error('Failed to load word bank');
       console.error(err);
@@ -108,40 +78,23 @@ export default function WordBank() {
   // ==================== Filtering & Sorting ====================
   useEffect(() => {
     let filtered = [...words];
-    
-    // 搜索过滤
     if (search) {
-      filtered = filtered.filter(w => 
+      filtered = filtered.filter(w =>
         w.text.toLowerCase().includes(search.toLowerCase()) ||
         w.definition.toLowerCase().includes(search.toLowerCase())
       );
     }
-    
-    // 掌握程度过滤
-    if (masteryFilter !== null) {
-      filtered = filtered.filter(w => w.mastery_level === masteryFilter);
-    }
-    
-    // 排序
     filtered.sort((a, b) => {
       switch (sortBy) {
-        case 'date_desc':
-          return new Date(b.added_at) - new Date(a.added_at);
-        case 'date_asc':
-          return new Date(a.added_at) - new Date(b.added_at);
-        case 'word_asc':
-          return a.text.localeCompare(b.text);
-        case 'word_desc':
-          return b.text.localeCompare(a.text);
-        case 'mastery':
-          return b.mastery_level - a.mastery_level;
-        default:
-          return 0;
+        case 'date_desc': return new Date(b.added_at) - new Date(a.added_at);
+        case 'date_asc': return new Date(a.added_at) - new Date(b.added_at);
+        case 'word_asc': return a.text.localeCompare(b.text);
+        case 'word_desc': return b.text.localeCompare(a.text);
+        default: return 0;
       }
     });
-    
     setFilteredWords(filtered);
-  }, [words, search, masteryFilter, sortBy]);
+  }, [words, search, sortBy]);
 
   // ==================== CRUD Operations ====================
   const confirmRemove = (entryId) => {
@@ -151,14 +104,12 @@ export default function WordBank() {
 
   const removeWord = async () => {
     if (!wordToDelete) return;
-    
     try {
       await wordBankAPI.remove(wordToDelete);
       setWords(words.filter((w) => w.id !== wordToDelete));
       message.success('Word removed from bank');
     } catch (err) {
       message.error('Failed to remove word');
-      console.error(err);
     } finally {
       setDeleteModalVisible(false);
       setWordToDelete(null);
@@ -170,7 +121,6 @@ export default function WordBank() {
       message.warning('No words selected');
       return;
     }
-
     Modal.confirm({
       title: 'Batch Delete',
       content: `Are you sure you want to delete ${selectedWords.size} words?`,
@@ -178,11 +128,7 @@ export default function WordBank() {
       okButtonProps: { danger: true },
       onOk: async () => {
         try {
-          const deletePromises = Array.from(selectedWords).map(id => 
-            wordBankAPI.remove(id)
-          );
-          
-          await Promise.all(deletePromises);
+          await Promise.all(Array.from(selectedWords).map(id => wordBankAPI.remove(id)));
           setWords(words.filter(w => !selectedWords.has(w.id)));
           setSelectedWords(new Set());
           setBatchDeleteMode(false);
@@ -194,98 +140,6 @@ export default function WordBank() {
     });
   };
 
-  // ==================== Review Functions ====================
-  const startReview = async () => {
-    try {
-      setReviewWords(words.filter(w => w.mastery_level < 3));
-      setReviewModalVisible(true);
-      setCurrentReviewIndex(0);
-      setShowDefinition(false);
-    } catch (err) {
-      message.error('Failed to load review words');
-      console.error(err);
-    }
-  };
-
-  const markReviewed = async (wordId, knewIt) => {
-    try {
-      await wordBankAPI.review(wordId, knewIt);
-      
-      const word = words.find(w => w.id === wordId);
-      if (!word) return;
-
-      if (knewIt && word.mastery_level < 3) {
-        setWords(words.map(w => {
-          if (w.id === wordId && w.mastery_level < 3) {
-            return { ...w, mastery_level: w.mastery_level + 1 };
-          }
-          return w;
-        }));
-      }
-      
-      setStats(prev => ({
-        ...prev,
-        today_reviewed: prev.today_reviewed + 1
-      }));
-    } catch (err) {
-      console.error('Failed to record review:', err);
-    }
-  };
-
-  // ==================== Mastery Update ====================
-  const updateMastery = async (entryId, newLevel) => {
-    try {
-      await wordBankAPI.updateMastery(entryId, newLevel);
-      setWords(words.map(w => 
-        w.id === entryId ? { ...w, mastery_level: newLevel } : w
-      ));
-      message.success('Mastery level updated');
-    } catch (err) {
-      message.error('Failed to update mastery level');
-      console.error(err);
-    }
-  };
-
-  // ==================== Export Functions ====================
-  const exportWords = async (format) => {
-    try {
-      const exportData = filteredWords;
-      
-      if (format === 'csv') {
-        // 生成 CSV 内容
-        const csvContent = [
-          ['Word', 'Definition', 'Mastery Level'],
-          ...exportData.map(w => [
-            w.text,
-            w.definition,
-            masteryConfig[w.mastery_level].label
-          ])
-        ].map(row => row.join(',')).join('\n');
-        
-        // 下载 CSV 文件
-        const blob = new Blob([csvContent], { type: 'text/csv' });
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `wordbank_${new Date().toISOString().split('T')[0]}.csv`;
-        a.click();
-      } else if (format === 'json') {
-        // 复制到剪贴板
-        await navigator.clipboard.writeText(JSON.stringify(exportData, null, 2));
-        message.success('Copied to clipboard');
-      } else if (format === 'text') {
-        // 复制为文本列表
-        const textContent = exportData.map(w => w.text).join('\n');
-        await navigator.clipboard.writeText(textContent);
-        message.success('Copied to clipboard');
-      }
-      
-      setExportModalVisible(false);
-    } catch (err) {
-      message.error('Export failed');
-    }
-  };
-
   // ==================== Speech ====================
   const speakWord = (text) => {
     if ('speechSynthesis' in window) {
@@ -293,303 +147,204 @@ export default function WordBank() {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = 'en-US';
       utterance.rate = 0.8;
-      utterance.onerror = () => message.warning('Speech synthesis failed');
       window.speechSynthesis.speak(utterance);
-    } else {
-      message.warning('Your browser does not support speech synthesis');
     }
   };
 
-  // ==================== Statistics ====================
-  const calculatedStats = {
-    ...stats,
-    progress: stats.total ? Math.round((stats.familiar + stats.mastered) / stats.total * 100) || 0 : 0,
-    dailyProgress: Math.min(Math.round((stats.today_reviewed / 10) * 100), 100),
-    avgMastery: stats.total ? 
-      Math.round(((stats.new * 0 + stats.learning * 1 + stats.familiar * 2 + stats.mastered * 3) / stats.total) * 100) / 100 : 0,
+  // ==================== Export ====================
+  const exportWords = async (format) => {
+    try {
+      const exportData = filteredWords;
+      if (format === 'csv') {
+        const csvContent = [
+          ['Word', 'Definition'],
+          ...exportData.map(w => [w.text, `"${(w.definition || '').replace(/"/g, '""')}"`])
+        ].map(row => row.join(',')).join('\n');
+        const blob = new Blob([csvContent], { type: 'text/csv' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `wordbank_${new Date().toISOString().split('T')[0]}.csv`;
+        a.click();
+      } else if (format === 'json') {
+        await navigator.clipboard.writeText(JSON.stringify(exportData, null, 2));
+        message.success('Copied to clipboard');
+      } else if (format === 'text') {
+        await navigator.clipboard.writeText(exportData.map(w => w.text).join('\n'));
+        message.success('Copied to clipboard');
+      }
+      setExportModalVisible(false);
+    } catch (err) {
+      message.error('Export failed');
+    }
   };
 
-  // ==================== UI Components ====================
-  const ReviewModal = () => (
-    <Modal
-      title="📖 Word Review"
-      open={reviewModalVisible}
-      onCancel={() => setReviewModalVisible(false)}
-      footer={null}
-      width={600}
-      centered
-    >
-      {reviewWords.length > 0 ? (
-        <div>
-          {/* 进度条 */}
-          <div style={{ marginBottom: 24 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-              <Text type="secondary">
-                {currentReviewIndex + 1} / {reviewWords.length}
-              </Text>
-              <Text type="success">
-                {Math.round(((currentReviewIndex + 1) / reviewWords.length) * 100)}%
-              </Text>
-            </div>
-            <Progress 
-              percent={Math.round(((currentReviewIndex + 1) / reviewWords.length) * 100)} 
-              showInfo={false}
-              strokeColor="#2563eb"
-            />
-          </div>
+  // ==================== Word Bank Learning ====================
+  const startLearning = () => {
+    if (words.length === 0) {
+      message.info('No words in your bank!');
+      return;
+    }
+    setLearningWords([...words]);
+    setLearningIndex(0);
+    setShowDef(false);
+    setLearningOpen(true);
+  };
 
-          {/* 当前单词 */}
-          <div style={{ textAlign: 'center', minHeight: 200, padding: '20px 0' }}>
-            <Title level={2} style={{ marginBottom: 16, color: '#1a1a2e' }}>
-              {reviewWords[currentReviewIndex].text}
-            </Title>
-            
-            {reviewWords[currentReviewIndex].part_of_speech && (
-              <Tag style={{ marginBottom: 16 }}>
-                {reviewWords[currentReviewIndex].part_of_speech}
-              </Tag>
-            )}
-            
-            {showDefinition ? (
-              <div style={{ textAlign: 'left', background: '#f9fafb', padding: 20, borderRadius: 12 }}>
-                <Text strong>Definition: </Text>
-                <Paragraph>{reviewWords[currentReviewIndex].definition}</Paragraph>
-                
-                {reviewWords[currentReviewIndex].example_sentence && (
-                  <>
-                    <Divider style={{ margin: '12px 0' }} />
-                    <Text strong>Example: </Text>
-                    <Text italic>"{reviewWords[currentReviewIndex].example_sentence}"</Text>
-                  </>
-                )}
-              </div>
-            ) : (
-              <Button 
-                type="link" 
-                onClick={() => setShowDefinition(true)}
-                size="large"
-              >
-                Show Definition
-              </Button>
-            )}
-          </div>
+  const handleLearningNext = () => {
+    if (learningIndex < learningWords.length - 1) {
+      setLearningIndex(prev => prev + 1);
+      setShowDef(false);
+    } else {
+      setLearningOpen(false);
+      message.success('Finished reviewing word bank!');
+    }
+  };
 
-          {/* 按钮组 */}
-          {showDefinition ? (
-            <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 24 }}>
-              <Button 
-                size="large"
-                onClick={() => {
-                  markReviewed(reviewWords[currentReviewIndex].id, false);
-                  if (currentReviewIndex < reviewWords.length - 1) {
-                    setCurrentReviewIndex(prev => prev + 1);
-                    setShowDefinition(false);
-                  } else {
-                    setReviewModalVisible(false);
-                    loadWordBank(); // 刷新数据
-                  }
-                }}
-              >
-                Need Review Again
-              </Button>
-              <Button 
-                type="primary"
-                size="large"
-                onClick={() => {
-                  markReviewed(reviewWords[currentReviewIndex].id, true);
-                  if (currentReviewIndex < reviewWords.length - 1) {
-                    setCurrentReviewIndex(prev => prev + 1);
-                    setShowDefinition(false);
-                  } else {
-                    setReviewModalVisible(false);
-                    loadWordBank(); // 刷新数据
-                  }
-                }}
-              >
-                I Know It
-              </Button>
-            </div>
-          ) : (
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 24 }}>
-              <Button 
-                onClick={() => {
-                  if (currentReviewIndex > 0) {
-                    setCurrentReviewIndex(prev => prev - 1);
-                    setShowDefinition(false);
-                  }
-                }}
-                disabled={currentReviewIndex === 0}
-              >
-                Previous
-              </Button>
-              <Button type="primary" onClick={() => setShowDefinition(true)}>
-                Check Definition
-              </Button>
-            </div>
-          )}
-        </div>
-      ) : (
-        <Empty description="No words to review today">
-          <Button onClick={() => setReviewModalVisible(false)}>
-            Close
-          </Button>
-        </Empty>
-      )}
-    </Modal>
-  );
+  const handleRemoveFromBank = async (entryId) => {
+    try {
+      await wordBankAPI.remove(entryId);
+      setWords(prev => prev.filter(w => w.id !== entryId));
 
-  const StatsModal = () => (
-    <Modal
-      title="📊 Learning Statistics"
-      open={statsModalVisible}
-      onCancel={() => setStatsModalVisible(false)}
-      footer={null}
-      width={500}
-    >
-      <div style={{ padding: '10px 0' }}>
-        {/* 总体进度 */}
-        <div style={{ marginBottom: 24 }}>
-          <Text strong>Overall Progress</Text>
-          <Progress percent={calculatedStats.progress} status="active" strokeColor="#2563eb" />
-        </div>
+      const updated = learningWords.filter(w => w.id !== entryId);
+      if (updated.length === 0) {
+        setLearningOpen(false);
+        setLearningWords([]);
+        message.success('Removed. No more words in bank.');
+        return;
+      }
 
-        {/* 掌握程度分布 */}
-        <Card size="small" style={{ marginBottom: 16 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-            <Text>🆕 New</Text>
-            <Text strong>{calculatedStats.new}</Text>
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-            <Text>📚 Learning</Text>
-            <Text strong>{stats.learning}</Text>
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-            <Text>✨ Familiar</Text>
-            <Text strong>{calculatedStats.familiar}</Text>
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Text>🌟 Mastered</Text>
-            <Text strong>{calculatedStats.mastered}</Text>
-          </div>
-        </Card>
+      setLearningWords(updated);
+      // If we removed the current or a later word, keep index; if removed earlier, decrement
+      const removedIdx = learningWords.findIndex(w => w.id === entryId);
+      if (removedIdx < learningIndex) {
+        setLearningIndex(prev => prev - 1);
+      } else if (learningIndex >= updated.length) {
+        setLearningIndex(updated.length - 1);
+      }
+      setShowDef(false);
+      message.success('Removed from bank');
+    } catch (err) {
+      message.error('Failed to remove');
+    }
+  };
 
-        {/* 统计数据 */}
-        <Row gutter={16}>
-          <Col span={12}>
-            <Card size="small">
-              <Statistic 
-                title="Total Words" 
-                value={calculatedStats.total} 
-                suffix="words"
-              />
-            </Card>
-          </Col>
-          <Col span={12}>
-            <Card size="small">
-              <Statistic 
-                title="Avg Mastery" 
-                value={calculatedStats.avgMastery} 
-                precision={2}
-                suffix="/3"
-              />
-            </Card>
-          </Col>
-        </Row>
+  // ==================== View All / Review / Mastered ====================
+  const addToBank = async (wordId) => {
+    try {
+      await dailyLearningAPI.addToBank(wordId);
+      message.success('Added to Word Bank!');
+      loadWordBank();
+    } catch (error) {
+      if (error.response?.status === 409) {
+        message.info('Already in Word Bank');
+      } else {
+        message.error('Failed to add to bank');
+      }
+    }
+  };
 
-        {/* 复习历史（简化版） */}
-        {stats.review_history.length > 0 && (
-          <div style={{ marginTop: 16 }}>
-            <Text strong>Recent Activity</Text>
-            <div style={{ maxHeight: 150, overflowY: 'auto', marginTop: 8 }}>
-              {stats.review_history.slice(0, 5).map((item, index) => (
-                <div key={index} style={{ 
-                  padding: '8px 0', 
-                  borderBottom: index < 4 ? '1px solid #f0f0f0' : 'none'
-                }}>
-                  <Text>{item.date}: </Text>
-                  <Text strong>{item.count} words</Text>
-                  <Text type="secondary"> reviewed</Text>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </Modal>
-  );
+  const loadAllWords = async (page = 1, search = '') => {
+    try {
+      setAllWordsLoading(true);
+      const res = await dailyLearningAPI.getAllWords(page, 50, search);
+      setAllWords(res.data.words || []);
+      setAllWordsTotal(res.data.total || 0);
+      setAllWordsPage(page);
+    } catch (error) {
+      message.error('Failed to load words');
+    } finally {
+      setAllWordsLoading(false);
+    }
+  };
 
-  const ExportModal = () => (
-    <Modal
-      title="📤 Export Word Bank"
-      open={exportModalVisible}
-      onCancel={() => setExportModalVisible(false)}
-      footer={null}
-    >
-      <div style={{ padding: '10px 0' }}>
-        <Alert
-          message={`Exporting ${masteryFilter !== null ? 
-            masteryConfig.find(m => m.value === masteryFilter)?.label : 'all'} words`}
-          type="info"
-          showIcon
-          style={{ marginBottom: 16 }}
-        />
-        
-        <Space direction="vertical" style={{ width: '100%' }}>
-          <Button 
-            block 
-            icon={<ExportOutlined />}
-            onClick={() => exportWords('csv')}
-          >
-            Export as CSV (for Excel)
-          </Button>
-          <Button 
-            block 
-            icon={<ExportOutlined />}
-            onClick={() => exportWords('json')}
-          >
-            Export as JSON
-          </Button>
-          <Button 
-            block 
-            icon={<ExportOutlined />}
-            onClick={() => exportWords('text')}
-          >
-            Copy as Text List
-          </Button>
-        </Space>
-      </div>
-    </Modal>
-  );
+  const openAllWords = () => {
+    setAllWordsSearch('');
+    loadAllWords(1, '');
+    setAllWordsOpen(true);
+  };
 
-  // ==================== Main Render ====================
+  const openReviewList = async () => {
+    try {
+      setReviewListLoading(true);
+      const res = await dailyLearningAPI.getReviewWords();
+      setReviewListWords(res.data.words || []);
+      setReviewListOpen(true);
+    } catch (error) {
+      message.error('Failed to load review words');
+    } finally {
+      setReviewListLoading(false);
+    }
+  };
+
+  const openMastered = async () => {
+    try {
+      setMasteredLoading(true);
+      const res = await dailyLearningAPI.getMasteredWords();
+      setMasteredWords(res.data.words || []);
+      setMasteredOpen(true);
+    } catch (error) {
+      message.error('Failed to load mastered words');
+    } finally {
+      setMasteredLoading(false);
+    }
+  };
+
+  // ==================== Mark Mastered by word_id ====================
+  const markMasteredByWordId = async (wordId) => {
+    try {
+      await dailyLearningAPI.markMastered(wordId);
+      message.success('Marked as mastered');
+      setAllWords(prev => prev.map(w =>
+        w.id === wordId ? { ...w, progress_status: 'mastered' } : w
+      ));
+    } catch (error) {
+      message.error('Failed to mark as mastered');
+    }
+  };
+
+  // ==================== Render ====================
+  const currentLearningWord = learningWords[learningIndex];
+
   return (
     <div className="page-container" style={{ padding: '24px' }}>
-      {/* Modals */}
+      {/* Delete Confirm Modal */}
       <Modal
         title="Remove Word"
         open={deleteModalVisible}
         onOk={removeWord}
         onCancel={() => setDeleteModalVisible(false)}
         okText="Remove"
-        cancelText="Cancel"
         okButtonProps={{ danger: true }}
       >
         <p>Are you sure you want to remove this word from your bank?</p>
       </Modal>
 
-      <ReviewModal />
-      <StatsModal />
-      <ExportModal />
+      {/* Export Modal */}
+      <Modal
+        title="Export Word Bank"
+        open={exportModalVisible}
+        onCancel={() => setExportModalVisible(false)}
+        footer={null}
+      >
+        <Space direction="vertical" style={{ width: '100%', padding: '10px 0' }}>
+          <Button block icon={<ExportOutlined />} onClick={() => exportWords('csv')}>
+            Export as CSV (for Excel)
+          </Button>
+          <Button block icon={<ExportOutlined />} onClick={() => exportWords('json')}>
+            Export as JSON
+          </Button>
+          <Button block icon={<ExportOutlined />} onClick={() => exportWords('text')}>
+            Copy as Text List
+          </Button>
+        </Space>
+      </Modal>
 
       {/* Header */}
       <div style={{ marginBottom: 24 }}>
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'space-between', 
-          alignItems: 'center',
-          flexWrap: 'wrap',
-          gap: 16,
-          marginBottom: 16
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          flexWrap: 'wrap', gap: 16, marginBottom: 16
         }}>
           <div>
             <Title level={2} style={{ margin: 0, fontWeight: 700, color: '#1a1a2e' }}>
@@ -598,70 +353,46 @@ export default function WordBank() {
             </Title>
             <Text type="secondary">{words.length} words saved</Text>
           </div>
-          
           <Space wrap>
-            {/* Daily Goal Progress */}
-            <Card size="small" style={{ borderRadius: 20, background: '#f0f9ff' }}>
-              <Space>
-                <StarOutlined style={{ color: '#f59e0b' }} />
-                <Text strong>{calculatedStats.today_reviewed}/10</Text>
-                <Text type="secondary">today</Text>
-              </Space>
-            </Card>
-
-            <Button 
+            <Button
               type="primary"
-              icon={<ReloadOutlined />}
-              onClick={startReview}
+              icon={<PlayCircleOutlined />}
+              onClick={startLearning}
               disabled={words.length === 0}
+              style={{ background: '#667eea', borderColor: '#667eea' }}
             >
-              Review Words
+              Learn Word Bank
             </Button>
-
-            <Button 
-              icon={<BarChartOutlined />}
-              onClick={() => setStatsModalVisible(true)}
-            >
-              Stats
-            </Button>
-
-            <Button 
-              icon={<ExportOutlined />}
-              onClick={() => setExportModalVisible(true)}
-            >
+            <Button icon={<ExportOutlined />} onClick={() => setExportModalVisible(true)}>
               Export
             </Button>
-
             {batchDeleteMode ? (
-              <Button 
-                danger
-                onClick={batchDelete}
-              >
-                Delete ({selectedWords.size})
-              </Button>
+              <>
+                <Button danger onClick={batchDelete}>Delete ({selectedWords.size})</Button>
+                <Button size="small" onClick={() => { setBatchDeleteMode(false); setSelectedWords(new Set()); }}>
+                  Cancel
+                </Button>
+              </>
             ) : (
-              <Button 
-                onClick={() => setBatchDeleteMode(true)}
-              >
-                Batch Select
-              </Button>
-            )}
-
-            {batchDeleteMode && (
-              <Button 
-                size="small"
-                onClick={() => {
-                  setBatchDeleteMode(false);
-                  setSelectedWords(new Set());
-                }}
-              >
-                Cancel
-              </Button>
+              <Button onClick={() => setBatchDeleteMode(true)}>Batch Select</Button>
             )}
           </Space>
         </div>
 
-        {/* Search and Filter Bar */}
+        {/* View Buttons */}
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
+          <Button icon={<EyeOutlined />} onClick={openAllWords}>
+            View All Words
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={openReviewList}>
+            View Review Words
+          </Button>
+          <Button icon={<StarOutlined />} onClick={openMastered}>
+            View Mastered Words
+          </Button>
+        </div>
+
+        {/* Search and Sort */}
         <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
           <Input
             placeholder="Search words or definitions..."
@@ -671,115 +402,18 @@ export default function WordBank() {
             style={{ width: 300, borderRadius: 8 }}
             allowClear
           />
-
-          <Select
-            value={sortBy}
-            onChange={setSortBy}
-            style={{ width: 200 }}
-            placeholder="Sort by"
-          >
+          <Select value={sortBy} onChange={setSortBy} style={{ width: 200 }}>
             {sortOptions.map(opt => (
               <Option key={opt.value} value={opt.value}>
                 <SortAscendingOutlined /> {opt.label}
               </Option>
             ))}
           </Select>
-
-          <Button 
-            icon={<ReloadOutlined />} 
-            onClick={loadWordBank}
-            loading={loading}
-          >
+          <Button icon={<ReloadOutlined />} onClick={loadWordBank} loading={loading}>
             Refresh
           </Button>
         </div>
       </div>
-
-      {/* Mastery Filter Tabs */}
-      <div style={{ marginBottom: 24 }}>
-        <Space wrap>
-          <Button 
-            size="large"
-            type={masteryFilter === null ? 'primary' : 'default'}
-            onClick={() => setMasteryFilter(null)}
-            style={{ borderRadius: 30, minWidth: 80 }}
-          >
-            All <Tag style={{ marginLeft: 4 }}>{calculatedStats.total}</Tag>
-          </Button>
-          {masteryConfig.map(level => (
-            <Button
-              key={level.value}
-              size="large"
-              type={masteryFilter === level.value ? 'primary' : 'default'}
-              onClick={() => setMasteryFilter(level.value)}
-              style={{ 
-                borderRadius: 30,
-                minWidth: 100,
-                background: masteryFilter === level.value ? level.color : level.bg,
-                borderColor: level.color,
-                color: masteryFilter === level.value ? '#fff' : level.color,
-              }}
-            >
-              {level.emoji} {level.label} 
-              <Tag style={{ 
-                marginLeft: 4,
-                background: masteryFilter === level.value ? 'rgba(255,255,255,0.2)' : '#fff',
-                border: 'none'
-              }}>
-                {stats[level.label.toLowerCase()] || 0}
-              </Tag>
-            </Button>
-          ))}
-        </Space>
-      </div>
-
-      {/* Statistics Cards */}
-      <Row gutter={[16, 16]} style={{ marginBottom: 24 }}>
-        <Col xs={24} sm={12} md={6}>
-          <Card hoverable style={{ borderRadius: 16, textAlign: 'center' }} size="small">
-            <Statistic 
-              title="Total Vocabulary" 
-              value={stats.total} 
-              prefix={<BookOutlined style={{ color: '#2563eb' }} />}
-              valueStyle={{ color: '#2563eb', fontWeight: 600, fontSize: 28 }}
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} md={6}>
-          <Card hoverable style={{ borderRadius: 16, textAlign: 'center' }} size="small">
-            <Statistic 
-              title="Mastery Progress" 
-              value={calculatedStats.progress} 
-              suffix="%"
-              prefix={<CheckCircleOutlined style={{ color: '#059669' }} />}
-              valueStyle={{ color: '#059669', fontWeight: 600, fontSize: 28 }}
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} md={6}>
-          <Card hoverable style={{ borderRadius: 16, textAlign: 'center' }} size="small">
-            <Statistic 
-              title="Today's Goal" 
-              value={calculatedStats.dailyProgress} 
-              suffix="%"
-              prefix={<StarOutlined style={{ color: '#d97706' }} />}
-              valueStyle={{ color: '#d97706', fontWeight: 600, fontSize: 28 }}
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} md={6}>
-          <Card hoverable style={{ borderRadius: 16, textAlign: 'center' }} size="small">
-            <Statistic 
-              title="Avg Mastery" 
-              value={stats.avgMastery} 
-              precision={1}
-              suffix="/3"
-              prefix={<BarChartOutlined style={{ color: '#7c3aed' }} />}
-              valueStyle={{ color: '#7c3aed', fontWeight: 600, fontSize: 28 }}
-            />
-          </Card>
-        </Col>
-      </Row>
 
       {/* Word List */}
       {loading ? (
@@ -792,181 +426,303 @@ export default function WordBank() {
             image={Empty.PRESENTED_IMAGE_SIMPLE}
             description={
               words.length === 0
-                ? 'No words saved yet. Start building your vocabulary!'
-                : 'No words match your filters'
+                ? 'No words saved yet. Add words from Daily Words!'
+                : 'No words match your search'
             }
           >
             {words.length === 0 ? (
-              <Button 
-                type="primary" 
-                href="/daily-words"
-                size="large"
-              >
+              <Button type="primary" href="/daily-words" size="large">
                 Go to Daily Words
               </Button>
             ) : (
-              <Button onClick={() => {
-                setSearch('');
-                setMasteryFilter(null);
-              }}>
-                Clear Filters
-              </Button>
+              <Button onClick={() => setSearch('')}>Clear Search</Button>
             )}
           </Empty>
         </Card>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {filteredWords.map((entry) => {
-            const mastery = masteryConfig[entry.mastery_level] || masteryConfig[0];
-            return (
-              <Card
-                key={entry.id}
-                style={{ 
-                  borderRadius: 16, 
-                  border: selectedWords.has(entry.id) ? '2px solid #2563eb' : '1px solid #e5e7eb',
-                  transition: 'all 0.2s',
-                  background: selectedWords.has(entry.id) ? '#eff6ff' : '#fff',
-                }}
-                bodyStyle={{ padding: '16px 24px' }}
-                hoverable
-              >
-                <div style={{ 
-                  display: 'flex', 
-                  justifyContent: 'space-between', 
-                  alignItems: 'center', 
-                  gap: 16,
-                  flexWrap: 'wrap',
-                }}>
-                  {/* Left: Word Info */}
-                  <div style={{ flex: 1, minWidth: 250 }}>
-                    {batchDeleteMode && (
-                      <input
-                        type="checkbox"
-                        checked={selectedWords.has(entry.id)}
-                        onChange={(e) => {
-                          const newSelected = new Set(selectedWords);
-                          if (e.target.checked) {
-                            newSelected.add(entry.id);
-                          } else {
-                            newSelected.delete(entry.id);
-                          }
-                          setSelectedWords(newSelected);
-                        }}
-                        style={{ marginRight: 12 }}
-                      />
-                    )}
-                    
-                    <Space size={12} align="center" wrap>
-                      <Title level={4} style={{ margin: 0, fontWeight: 600 }}>
-                        {entry.text}
-                      </Title>
-                      <Tag style={{
-                        borderRadius: 16,
-                        color: mastery.color,
-                        background: mastery.bg,
-                        border: 'none',
-                        fontWeight: 500,
-                        padding: '4px 12px',
-                      }}>
-                        {mastery.emoji} {mastery.label}
-                      </Tag>
-                      {entry.difficulty_level && (
-                        <Tag color={
-                          entry.difficulty_level === 'beginner' ? 'green' :
-                          entry.difficulty_level === 'intermediate' ? 'blue' : 'orange'
-                        } style={{ borderRadius: 16 }}>
-                          {entry.difficulty_level}
-                        </Tag>
-                      )}
-                      {entry.part_of_speech && (
-                        <Tag style={{ borderRadius: 16 }}>{entry.part_of_speech}</Tag>
-                      )}
-                    </Space>
-                    
-                    <Paragraph style={{ 
-                      margin: '8px 0 4px', 
-                      color: '#374151', 
-                      fontSize: 15,
-                      paddingLeft: batchDeleteMode ? 28 : 0,
-                    }}>
-                      {entry.definition}
-                    </Paragraph>
-                    
-                    {entry.example_sentence && (
-                      <Text italic style={{ 
-                        color: '#6b7280', 
-                        fontSize: 14,
-                        display: 'block',
-                        marginBottom: 4,
-                        paddingLeft: batchDeleteMode ? 28 : 0,
-                      }}>
-                        "{entry.example_sentence}"
-                      </Text>
-                    )}
-                    
-                    <div style={{ paddingLeft: batchDeleteMode ? 28 : 0 }}>
-                      <Text type="secondary" style={{ fontSize: 12 }}>
-                        Added: {new Date(entry.added_at).toLocaleDateString()}
-                      </Text>
-                      {entry.last_reviewed && (
-                        <Text type="secondary" style={{ fontSize: 12, marginLeft: 16 }}>
-                          Last review: {new Date(entry.last_reviewed).toLocaleDateString()}
-                        </Text>
-                      )}
-                    </div>
-                  </div>
-                  
-                  {/* Right: Actions */}
-                  {!batchDeleteMode && (
-                    <Space size={8}>
-                      <Tooltip title="Listen">
-                        <Button 
-                          shape="circle" 
-                          icon={<SoundOutlined />} 
-                          onClick={() => speakWord(entry.text)}
-                          style={{ color: '#2563eb', borderColor: '#93c5fd' }}
-                        />
-                      </Tooltip>
-                      
-                      <Tooltip title="Update mastery level">
-                        <Select
-                          value={entry.mastery_level}
-                          onChange={(value) => updateMastery(entry.id, value)}
-                          style={{ width: 100 }}
-                          size="small"
-                          dropdownMatchSelectWidth={false}
-                        >
-                          {masteryConfig.map(level => (
-                            <Option key={level.value} value={level.value}>
-                              <Tag style={{ 
-                                color: level.color, 
-                                background: level.bg,
-                                border: 'none',
-                                marginRight: 0
-                              }}>
-                                {level.emoji} {level.label}
-                              </Tag>
-                            </Option>
-                          ))}
-                        </Select>
-                      </Tooltip>
-                      
-                      <Tooltip title="Remove">
-                        <Button 
-                          shape="circle" 
-                          icon={<DeleteOutlined />} 
-                          danger
-                          onClick={() => confirmRemove(entry.id)}
-                        />
-                      </Tooltip>
-                    </Space>
+          {filteredWords.map((entry) => (
+            <Card
+              key={entry.id}
+              style={{
+                borderRadius: 16,
+                border: selectedWords.has(entry.id) ? '2px solid #2563eb' : '1px solid #e5e7eb',
+                background: selectedWords.has(entry.id) ? '#eff6ff' : '#fff',
+                transition: 'all 0.2s',
+              }}
+              styles={{ body: { padding: '16px 24px' } }}
+              hoverable
+            >
+              <div style={{
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                gap: 16, flexWrap: 'wrap',
+              }}>
+                <div style={{ flex: 1, minWidth: 250 }}>
+                  {batchDeleteMode && (
+                    <input
+                      type="checkbox"
+                      checked={selectedWords.has(entry.id)}
+                      onChange={(e) => {
+                        const newSelected = new Set(selectedWords);
+                        if (e.target.checked) newSelected.add(entry.id);
+                        else newSelected.delete(entry.id);
+                        setSelectedWords(newSelected);
+                      }}
+                      style={{ marginRight: 12 }}
+                    />
                   )}
+                  <Space size={12} align="center" wrap>
+                    <Title level={4} style={{ margin: 0, fontWeight: 600 }}>{entry.text}</Title>
+                    {entry.difficulty_level && (
+                      <Tag color={
+                        entry.difficulty_level === 'beginner' ? 'green' :
+                        entry.difficulty_level === 'intermediate' ? 'blue' : 'orange'
+                      } style={{ borderRadius: 16 }}>
+                        {entry.difficulty_level}
+                      </Tag>
+                    )}
+                    {entry.part_of_speech && (
+                      <Tag style={{ borderRadius: 16 }}>{entry.part_of_speech}</Tag>
+                    )}
+                  </Space>
+                  <Paragraph style={{ margin: '8px 0 4px', color: '#374151', fontSize: 15 }}>
+                    {entry.definition}
+                  </Paragraph>
+                  {entry.example_sentence && (
+                    <Text italic style={{ color: '#6b7280', fontSize: 14, display: 'block', marginBottom: 4 }}>
+                      &ldquo;{entry.example_sentence}&rdquo;
+                    </Text>
+                  )}
+                  <Text type="secondary" style={{ fontSize: 12 }}>
+                    Added: {new Date(entry.added_at).toLocaleDateString()}
+                  </Text>
                 </div>
-              </Card>
-            );
-          })}
+                {!batchDeleteMode && (
+                  <Space size={8}>
+                    <Tooltip title="Listen">
+                      <Button
+                        shape="circle"
+                        icon={<SoundOutlined />}
+                        onClick={() => speakWord(entry.text)}
+                        style={{ color: '#2563eb', borderColor: '#93c5fd' }}
+                      />
+                    </Tooltip>
+                    <Tooltip title="Remove">
+                      <Button
+                        shape="circle"
+                        icon={<DeleteOutlined />}
+                        danger
+                        onClick={() => confirmRemove(entry.id)}
+                      />
+                    </Tooltip>
+                  </Space>
+                )}
+              </div>
+            </Card>
+          ))}
         </div>
       )}
+
+      {/* ==================== Word Bank Learning Modal ==================== */}
+      <Modal
+        title={null}
+        open={learningOpen}
+        onCancel={() => setLearningOpen(false)}
+        footer={null}
+        width={640}
+        centered
+        styles={{ body: { padding: '24px' } }}
+      >
+        {currentLearningWord && (
+          <div>
+            <div style={{ marginBottom: 20 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <Text type="secondary">Word Bank Study</Text>
+                <Text strong>{learningIndex + 1} / {learningWords.length}</Text>
+              </div>
+              <Progress
+                percent={Math.round(((learningIndex + 1) / learningWords.length) * 100)}
+                showInfo={false}
+                strokeColor={{ from: '#059669', to: '#10b981' }}
+              />
+            </div>
+
+            <div style={{ textAlign: 'center', minHeight: 220, padding: '20px 0' }}>
+              <Title level={1} style={{ margin: 0, color: '#1a1a2e', fontSize: 36 }}>
+                {currentLearningWord.text}
+              </Title>
+              <Button
+                type="text"
+                icon={<SoundOutlined />}
+                onClick={() => speakWord(currentLearningWord.text)}
+                style={{ color: '#059669', marginTop: 4 }}
+              >
+                Listen
+              </Button>
+
+              {showDef ? (
+                <div style={{
+                  textAlign: 'left', background: '#ecfdf5', padding: 20, borderRadius: 12, marginTop: 16
+                }}>
+                  <Text strong style={{ color: '#059669' }}>Definition:</Text>
+                  <Paragraph style={{ margin: '8px 0', fontSize: 15 }}>
+                    {currentLearningWord.definition}
+                  </Paragraph>
+                  {currentLearningWord.example_sentence && (
+                    <>
+                      <Divider style={{ margin: '12px 0' }} />
+                      <Text strong style={{ color: '#059669' }}>Example:</Text>
+                      <Paragraph italic style={{ margin: '8px 0', color: '#6b7280' }}>
+                        &ldquo;{currentLearningWord.example_sentence}&rdquo;
+                      </Paragraph>
+                    </>
+                  )}
+                </div>
+              ) : (
+                <Button type="dashed" size="large" onClick={() => setShowDef(true)} style={{ marginTop: 16 }}>
+                  Show Definition
+                </Button>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'center', marginTop: 20, flexWrap: 'wrap' }}>
+              <Button
+                size="large"
+                onClick={handleLearningNext}
+                type="primary"
+                style={{ minWidth: 120 }}
+              >
+                {learningIndex < learningWords.length - 1 ? 'Next Word' : 'Finish'}
+              </Button>
+              <Tooltip title="Remove this word from your bank">
+                <Button
+                  size="large"
+                  danger
+                  icon={<CloseOutlined />}
+                  onClick={() => handleRemoveFromBank(currentLearningWord.id)}
+                  style={{ minWidth: 120 }}
+                >
+                  Remove from Bank
+                </Button>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* ==================== All Words Modal ==================== */}
+      <Modal
+        title={`All Words (${allWordsTotal})`}
+        open={allWordsOpen}
+        onCancel={() => setAllWordsOpen(false)}
+        footer={null}
+        width={750}
+      >
+        <Input
+          placeholder="Search words..."
+          prefix={<SearchOutlined />}
+          value={allWordsSearch}
+          onChange={(e) => { setAllWordsSearch(e.target.value); loadAllWords(1, e.target.value); }}
+          allowClear
+          style={{ marginBottom: 16 }}
+        />
+        <Spin spinning={allWordsLoading}>
+          <List
+            dataSource={allWords}
+            pagination={{
+              current: allWordsPage, total: allWordsTotal, pageSize: 50,
+              onChange: (page) => loadAllWords(page, allWordsSearch), size: 'small',
+            }}
+            renderItem={(word) => (
+              <List.Item actions={[
+                <Button
+                  key="bank"
+                  type="text"
+                  icon={word.in_word_bank ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={word.in_word_bank}
+                  onClick={() => addToBank(word.id)}
+                  size="small"
+                >
+                  {word.in_word_bank ? 'In Bank' : 'Add to Bank'}
+                </Button>,
+                word.progress_status === 'mastered' ? (
+                  <Tag key="status" color="green">mastered</Tag>
+                ) : (
+                  <Button
+                    key="mastered"
+                    type="text"
+                    icon={<StarOutlined />}
+                    onClick={() => markMasteredByWordId(word.id)}
+                    size="small"
+                    style={{ color: '#059669' }}
+                  >
+                    Mastered
+                  </Button>
+                ),
+              ].filter(Boolean)}>
+                <List.Item.Meta
+                  title={<Space><Text strong>{word.text}</Text><Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} /></Space>}
+                  description={word.definition}
+                />
+
+              </List.Item>
+            )}
+          />
+        </Spin>
+      </Modal>
+
+      {/* ==================== Review Words Modal ==================== */}
+      <Modal
+        title={`Review Words (${reviewListWords.length})`}
+        open={reviewListOpen}
+        onCancel={() => setReviewListOpen(false)}
+        footer={null}
+        width={700}
+      >
+        <Spin spinning={reviewListLoading}>
+          <List
+            dataSource={reviewListWords}
+            renderItem={(word) => (
+              <List.Item actions={[
+                <Button key="bank" type="text" icon={<PlusOutlined />} onClick={() => addToBank(word.word_id)} size="small">Add to Bank</Button>,
+              ]}>
+                <List.Item.Meta
+                  title={<Space><Text strong>{word.text}</Text><Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} /></Space>}
+                  description={word.definition}
+                />
+              </List.Item>
+            )}
+            locale={{ emptyText: <Empty description="No review words" /> }}
+          />
+        </Spin>
+      </Modal>
+
+      {/* ==================== Mastered Words Modal ==================== */}
+      <Modal
+        title={`Mastered Words (${masteredWords.length})`}
+        open={masteredOpen}
+        onCancel={() => setMasteredOpen(false)}
+        footer={null}
+        width={700}
+      >
+        <Spin spinning={masteredLoading}>
+          <List
+            dataSource={masteredWords}
+            pagination={{ pageSize: 20 }}
+            renderItem={(word) => (
+              <List.Item actions={[
+                <Button key="bank" type="text" icon={<PlusOutlined />} onClick={() => addToBank(word.word_id)} size="small">Add to Bank</Button>,
+              ]}>
+                <List.Item.Meta
+                  title={<Space><Text strong>{word.text}</Text><Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} /></Space>}
+                  description={word.definition}
+                />
+              </List.Item>
+            )}
+            locale={{ emptyText: <Empty description="No mastered words yet" /> }}
+          />
+        </Spin>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
Summary

Redesign the Daily Words and Word Bank modules to provide a structured, Baicizhan-style learning experience. Daily Words now serves as the central learning hub with dedicated learning sessions (one word at a time with show/hide definition), a review system for accumulated "review later" words, and a mastered words tracker. Word Bank is simplified to a personal vocabulary collection with a study mode, removing the old mastery states and in-place review.The Home page "Words Learned" stat now displays real data from the backend.

Files Changed

Backend — New Files
  - backend/app/models/user_word_progress.py — New model tracking per-user word status (pending / review / mastered)
  - backend/app/routes/daily_learning.py — 8 new API endpoints: today's words, update status, review/mastered/all word
  lists, stats, mark-mastered-by-word-id, add-to-bank

Backend — Modified Files
  - backend/app/__init__.py — Register daily_learning_bp blueprint; fix AWL.csv seed path (was missing one directory
  level)
  - backend/app/models/__init__.py — Add ReviewHistory and UserWordProgress to exports
  - backend/app/models/user.py — Add word_progress relationship
  - backend/app/models/word.py — Add user_word_progress relationship

Frontend — Modified Files
  - frontend/src/api/index.js — Add dailyLearningAPI with all new endpoints
  - frontend/src/pages/DailyWords.jsx — Full rewrite: landing page with Start Learning / Start Review / Mastered cards,
  word-by-word learning & review modals, preview/all-words/review-list/mastered-list modals, settings
  - frontend/src/pages/WordBank.jsx — Full rewrite: removed mastery filters / review / stats, added Learn Word Bank mode
   with in-session removal, added View All / Review / Mastered word list modals
  - frontend/src/pages/Home.jsx — Fetch real "Words Learned" count from /daily-learning/stats

How to Test

  1. Fresh start: Delete backend/instance/app.db and restart the backend so the database re-seeds with 570 AWL words.
  2. Daily Words — Learning: Open Daily Words, verify 3 action cards are shown. Click "Start Learning", go through words
   one by one, test "Show Definition", "I've Mastered", "Review Later", and "Add to Bank".
  3. No re-fill on same day: After completing all words, reload the page — pending count should remain 0 until the next
  day. Learn a few words and reload — count should decrease, not refill.
  4. Increase daily count: Change daily count from e.g. 10 to 15 — verify 5 additional words are assigned immediately.
  5. Carry-over: If possible, manually set assigned_date to yesterday for some pending words and verify they carry over
  correctly.
  6. Review flow: Mark some words as "Review Later", click "Start Review", choose review count, go through review
  session with "I've Mastered" / "Still Need Review".
  7. Word Bank: Add words from learning, verify they appear in Word Bank. Test "Learn Word Bank" mode including "Remove
  from Bank" during study. Verify search, sort, batch delete, and export still work.
  8. Add to Bank persistence: Add a word to bank, reload the page — the button should remain grayed out showing "In
  Bank".
  9. Home page: Verify "Words Learned" shows the correct count (mastered + review words).
  10. Other modules: Verify Listening, Speaking, AI Chat, Profile, Login/Register are unaffected.

Notes

  - The user_word_progress table is created automatically by db.create_all() on backend startup. No manual migration is
  needed.
  - The old daily_words.py route (GET /api/daily-words) and wordBankAPI.review / wordBankAPI.updateMastery /
  wordBankAPI.getStats endpoints still exist for backward compatibility but are no longer called by the frontend.
  - frontend/src/utils/awlUtils.js is no longer imported by any component (the frontend now relies entirely on the
  backend for word data) but has not been deleted.
  - Daily word count is stored in localStorage (dailyWordsCount key). It is not synced across devices.
  - The AWL.csv seed path fix (__init__.py line 72) changes from 2 to 3 levels of os.path.dirname — this was a
  pre-existing bug that only surfaced because the old frontend loaded words directly from the CSV file.