### PR TITLE
Add listening questions

### DIFF
--- a/generated_questions_md/Am_I_Normal_Trailer_questions.md
+++ b/generated_questions_md/Am_I_Normal_Trailer_questions.md
@@ -1,0 +1,243 @@
+# Question Set: Am_I_Normal_Trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. Who is Mona Trellaby?  
+   A. A teacher  
+   B. A journalist  
+   C. A musician  
+   D. An athlete  
+   **Answer:** B  
+   **Explanation:** The transcript says, “I’m Mona Trellaby and I’m a data journalist.”
+
+2. What does Mona use numbers for?  
+   A. Cooking recipes  
+   B. Making sense of the world  
+   C. Counting pets  
+   D. Buying groceries  
+   **Answer:** B  
+   **Explanation:** She says, “Numbers help me make sense of a chaotic world.”
+
+3. Which podcast is Mona working on?  
+   A. “Data for All”  
+   B. “Am I normal?”  
+   C. “Numbers and Chaos”  
+   D. “Friendship Facts”  
+   **Answer:** B  
+   **Explanation:** The transcript mentions, “Our new podcast from the Ted Audio Collective is Am I normal?”
+
+4. Mona asks how many close friends she needs. This is an example of:  
+   A. A math problem  
+   B. A personal question  
+   C. A science experiment  
+   D. A cooking recipe  
+   **Answer:** B  
+   **Explanation:** It is a question about her personal life, not a calculation.
+
+5. Mona says numbers never tell the whole story. What does this mean?  
+   A. Numbers are always wrong  
+   B. Numbers are incomplete  
+   C. Numbers are too simple  
+   D. Numbers are useless  
+   **Answer:** B  
+   **Explanation:** She says, “numbers never tell the whole story,” meaning they are incomplete.
+
+6. Mona will dig up stuff your dentist won’t tell you about:  
+   A. Teeth whitening  
+   B. Hair dye  
+   C. Diet  
+   D. Exercise  
+   **Answer:** A  
+   **Explanation:** She says, “dig up some stuff your dentist won’t tell you” and earlier asks, “Is teeth whitening a scam?”
+
+7. Mona says she will figure out how long it takes to get over a:  
+   A. Breakup  
+   B. Exam  
+   C. Job interview  
+   D. Vacation  
+   **Answer:** A  
+   **Explanation:** She mentions, “I’ll figure out how long it takes to get over a breakup.”
+
+8. The podcast is produced by which organization?  
+   A. Ted Audio Collective  
+   B. BBC  
+   C. NPR  
+   D. CNN  
+   **Answer:** A  
+   **Explanation:** The transcript says, “Our new podcast from the Ted Audio Collective.”
+
+### Fill in the Blank (6)
+
+1. Mona says numbers help her make sense of a chaotic ____.  
+   **Answer:** world  
+   **Explanation:** The transcript: “Numbers help me make sense of a chaotic world.”
+
+2. Mona says numbers never tell the whole ____.  
+   **Answer:** story  
+   **Explanation:** She says, “numbers never tell the whole story.”
+
+3. Mona says she will dig up some stuff your dentist won’t tell you about ____.  
+   **Answer:** teeth whitening  
+   **Explanation:** She asks, “Is teeth whitening a scam?”
+
+4. Mona says she will figure out how long it takes to get over a ____.  
+   **Answer:** breakup  
+   **Explanation:** She says, “how long it takes to get over a breakup.”
+
+5. Mona says she will find out what we’ve got totally wrong about making a ____.  
+   **Answer:** baby  
+   **Explanation:** She says, “what we’ve got totally wrong about making a baby.”
+
+6. Mona says the podcast will dig into how data shapes our ____.  
+   **Answer:** understanding  
+   **Explanation:** She says, “how data shapes our understanding of the world.”
+
+### Short Answer (6)
+
+1. What is Mona’s profession?  
+   **Answer:** Data journalist  
+   **Explanation:** The transcript opens with “I’m Mona Trellaby and I’m a data journalist.”
+
+2. What is the title of Mona’s podcast?  
+   **Answer:** “Am I normal?”  
+   **Explanation:** She says, “Our new podcast from the Ted Audio Collective is Am I normal?”
+
+3. What question does Mona ask about men and fertility?  
+   **Answer:** Should men be as concerned about their fertility as she is?  
+   **Explanation:** She lists the question, “Should men be as concerned about their fertility as I am?”
+
+4. What does Mona say about spreadsheets?  
+   **Answer:** They are orderly and comforting.  
+   **Explanation:** She says, “there’s something orderly and comforting about the boxes of a spreadsheet.”
+
+5. What kind of emails did Mona receive after the breakup study?  
+   **Answer:** Emails bleeding heartbreak.  
+   **Explanation:** She mentions, “I got these emails that were bleeding heartbreak from people.”
+
+6. Who helps Mona in the podcast?  
+   **Answer:** Her mom.  
+   **Explanation:** She says, “my mom is here to help.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. **Who is speaking in the transcript?**  
+   A. A dentist  
+   B. Mona Trellaby  
+   C. A scientist  
+   D. A podcast host from Ted Audio Collective  
+   **Answer:** B  
+   **Explanation:** The speaker introduces herself as “Mona Trellaby.”
+
+2. **What is Mona’s profession?**  
+   A. Teacher  
+   B. Data journalist  
+   C. Dentist  
+   D. Psychologist  
+   **Answer:** B  
+   **Explanation:** She says, “I’m a data journalist.”
+
+3. **According to Mona, what do numbers help her do?**  
+   A. Cook meals  
+   B. Make sense of a chaotic world  
+   C. Write poetry  
+   D. Build computers  
+   **Answer:** B  
+   **Explanation:** She states, “Numbers help me make sense of a chaotic world.”
+
+4. **Which question does Mona ask about teeth?**  
+   A. How many teeth do we have?  
+   B. Is teeth whitening a scam?  
+   C. When should we floss?  
+   D. How long does a tooth last?  
+   **Answer:** B  
+   **Explanation:** She lists the question, “Is teeth whitening a scam?”
+
+5. **What is the title of Mona’s new podcast?**  
+   A. Data Chaos  
+   B. Am I normal?  
+   C. The Spreadsheet Life  
+   D. Friendship Decay  
+   **Answer:** B  
+   **Explanation:** She says, “Our new podcast … is Am I normal?”
+
+6. **Which topic will Mona explore in this season of the podcast?**  
+   A. Dentistry  
+   B. Parenting styles  
+   C. Friendships  
+   D. Fertility  
+   **Answer:** C  
+   **Explanation:** She says, “I’m going to explore friendships.”
+
+7. **What does Mona say about the state of friendships?**  
+   A. They are growing stronger  
+   B. They are decaying  
+   C. They are unchanged  
+   D. They are irrelevant  
+   **Answer:** B  
+   **Explanation:** She says, “Are all of our friendships decaying right now? I think the short answer is yes.”
+
+8. **What does Mona claim dentists often omit?**  
+   A. The cost of treatment  
+   B. Basic facts about dentistry  
+   C. The need for flossing  
+   D. The color of dental tools  
+   **Answer:** B  
+   **Explanation:** She says, “There are some very basic things in dentistry that we don’t have, tons of good evidence.”
+
+---
+
+### Fill in the Blank (6)
+
+1. Mona says numbers never tell the ___ story.  
+   **Answer:** whole  
+   **Explanation:** “Numbers never tell the whole story.”
+
+2. She will dig into how data shapes our ___ of the world.  
+   **Answer:** understanding  
+   **Explanation:** “How data shapes our understanding of the world.”
+
+3. She asks how many close friends do I actually ___?  
+   **Answer:** need  
+   **Explanation:** “How many close friends do I actually need?”
+
+4. She wonders if men should be as concerned about their ___ as she is.  
+   **Answer:** fertility  
+   **Explanation:** “Should men be as concerned about their fertility as I am?”
+
+5. She will figure out how long it takes to get over a ___?  
+   **Answer:** breakup  
+   **Explanation:** “How long will it take me to get over my breakup?”
+
+6. She says the truth is life is ___.  
+   **Answer:** messy  
+   **Explanation:** “The truth is life is messy.”
+
+---
+
+### Short Answer (6)
+
+1. **What is Mona’s main goal with using numbers?**  
+   **Answer:** To make sense of a chaotic world and understand herself within that chaos.  
+   **Explanation:** She explains that numbers help her “make sense of a chaotic world” and “understand how I fit into that chaos.”
+
+2. **Name one question Mona asks about relationships.**  
+   **Answer:** “How many close friends do I actually need?”  
+   **Explanation:** This question is listed among the ones she asks.
+
+3. **What evidence does Mona mention regarding dentistry?**  
+   **Answer:** She says there are basic facts dentists won’t tell you, and there is “tons of good evidence.”  
+   **Explanation:** She explicitly states, “There are some very basic things in dentistry that we don’t have, tons of good evidence.”
+
+4. **What did Mona discover from breakup emails?**  
+   **Answer:** People were devastated years after a bad breakup.  
+   **Explanation:** She recounts, “I got these emails that were bleeding heartbreak from people who were just devastated years after a bad breakup.”
+
+5. **How does Mona describe scientists’ language about gametes?**  
+   **Answer:** It is influenced by gender roles of parenting.  
+   **Explanation:** She says, “Even some of the ways in

--- a/generated_questions_md/Better_Human_Trailer_questions.md
+++ b/generated_questions_md/Better_Human_Trailer_questions.md
@@ -1,0 +1,229 @@
+# Question Set: Better_Human_Trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. Who is the host of the podcast?  
+   A. Ted  
+   B. Chris Duffy  
+   C. John  
+   D. Sarah  
+   **Answer:** B  
+   **Explanation:** The transcript says, “Hi, I'm Chris Duffy and I am the host…”.
+
+2. What is the name of the podcast?  
+   A. Better People  
+   B. How to Be a Better Human  
+   C. Human Better  
+   D. The Better Podcast  
+   **Answer:** B  
+   **Explanation:** The host introduces the show as “Ted's new podcast How to Be a Better Human”.
+
+3. When does the podcast start?  
+   A. January 1st  
+   B. January 11th  
+   C. February 1st  
+   D. March 11th  
+   **Answer:** B  
+   **Explanation:** The transcript ends with “Coming January 11th”.
+
+4. What does the host say people want to do?  
+   A. Be less terrible  
+   B. Be more terrible  
+   C. Stay the same  
+   D. Stop listening  
+   **Answer:** A  
+   **Explanation:** He says the podcast offers “actionable insights on how to be a little less terrible”.
+
+5. What is one way to connect with others mentioned?  
+   A. By sharing a secret  
+   B. By sharing an experience  
+   C. By ignoring  
+   D. By shouting  
+   **Answer:** B  
+   **Explanation:** The transcript says, “Connection happens by sharing an experience…”.
+
+6. What does the host say you don't have to be to change the world?  
+   A. A teacher  
+   B. An advocate  
+   C. A musician  
+   D. A politician  
+   **Answer:** B  
+   **Explanation:** He says, “You don't have to be an advocate to change the way…”.
+
+7. What are some roles the podcast talks about?  
+   A. Partners, listeners, allies, activists  
+   B. Doctors, teachers, chefs  
+   C. Students, athletes  
+   D. None  
+   **Answer:** A  
+   **Explanation:** The host lists those roles in the description.
+
+8. What does the host say most people are?  
+   A. Not sure where to begin  
+   B. Already perfect  
+   C. Not listening  
+   D. Too busy  
+   **Answer:** A  
+   **Explanation:** He says, “Most of us want to be better, but we're just not sure where to begin.”
+
+---
+
+### Fill in the Blank (6)
+
+1. The host says we are “a little stuck” and we “don’t know how to ___.”  
+   **Answer:** improve  
+   **Explanation:** The transcript says, “We don’t know how to improve.”
+
+2. The podcast is a “Ted’s new podcast ___.”  
+   **Answer:** How to Be a Better Human  
+   **Explanation:** That is the title given by the host.
+
+3. Connection happens by sharing an experience or by connecting ___ through conversation.  
+   **Answer:** verbally  
+   **Explanation:** The transcript says, “by connecting verbally through conversation.”
+
+4. You have to be able to share your hopes, dreams, emotions, and you have to get the other person to be ___ .  
+   **Answer:** open  
+   **Explanation:** The host says, “you have to get the other person to be open.”
+
+5. The host says it’s about modeling your values in your day‑to‑day ___ .  
+   **Answer:** actions  
+   **Explanation:** He mentions “modeling your values in your day‑to‑day actions.”
+
+6. The podcast will start on ___ 11th.  
+   **Answer:** January  
+   **Explanation:** The final line says “Coming January 11th.”
+
+---
+
+### Short Answer (6)
+
+1. **Question:** Who is the host of the
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. Who is the host of the podcast mentioned in the transcript?  
+   A. Ted  
+   B. Chris Duffy  
+   C. Sarah  
+   D. Alex  
+   **Answer:** B. Chris Duffy  
+   **Explanation:** The transcript says, “Hi, I'm Chris Duffy and I am the host of Ted's new podcast.”
+
+2. What is the title of the podcast?  
+   A. Better Together  
+   B. How to Be a Better Human  
+   C. The Human Experience  
+   D. Everyday Excellence  
+   **Answer:** B. How to Be a Better Human  
+   **Explanation:** The host introduces the show as “How to Be a Better Human.”
+
+3. Which of the following roles is NOT mentioned as a way to be “a little less terrible”?  
+   A. Partner  
+   B. Listener  
+   C. Teacher  
+   D. Activist  
+   **Answer:** C. Teacher  
+   **Explanation:** The transcript lists partners, listeners, allies, activists, but not teachers.
+
+4. According to the transcript, how can connection happen?  
+   A. By sending emails  
+   B. By sharing an experience or conversation  
+   C. By watching television together  
+   D. By playing video games  
+   **Answer:** B. By sharing an experience or conversation  
+   **Explanation:** The speaker says, “Connection happens by sharing an experience or by connecting verbally through conversation.”
+
+5. What does the host suggest you should do to help yourself?  
+   A. Take a vacation  
+   B. Put yourself in the drive seat  
+   C. Buy new clothes  
+   D. Watch a movie  
+   **Answer:** B. Put yourself in the drive seat  
+   **Explanation:** He says, “put yourself in the drive seat to say, is this helping or harming me?”
+
+6. What does the host say you do not have to be in order to influence how others see the world?  
+   A. A teacher  
+   B. A politician  
+   C. An advocate  
+   D. A scientist  
+   **Answer:** C. An advocate  
+   **Explanation:** He states, “You don't have to be an advocate to change the way in person sees the world.”
+
+7. When does the podcast start airing?  
+   A. January 1st  
+   B. January 11th  
+   C. February 1st  
+   D. March 11th  
+   **Answer:** B. January 11th  
+   **Explanation:** The transcript ends with “Coming January 11th, wherever you listen to podcasts.”
+
+8. Which of the following is a suggested way to be a better human, according to the transcript?  
+   A. Avoid conversations  
+   B. Model your values in day‑to‑day actions  
+   C. Keep your emotions hidden  
+   D. Ignore others' hopes  
+   **Answer:** B. Model your values in day‑to‑day actions  
+   **Explanation:** The speaker says, “It’s really about just modeling your values in your day‑to‑day actions.”
+
+---
+
+### Fill in the Blank (6)
+
+1. The podcast is hosted by ____.  
+   **Answer:** Chris Duffy  
+   **Explanation:** The transcript introduces the host as “Hi, I'm Chris Duffy.”
+
+2. The show’s title is “How to Be a ____ Human.”  
+   **Answer:** Better  
+   **Explanation:** The title is “How to Be a Better Human.”
+
+3. Connection can happen by sharing an experience or by connecting verbally through ____.  
+   **Answer:** conversation  
+   **Explanation:** The transcript says, “by connecting verbally through conversation.”
+
+4. The host says you should put yourself in the __ seat.  
+   **Answer:** drive  
+   **Explanation:** He advises, “put yourself in the drive seat.”
+
+5. The podcast will start airing on January __th.  
+   **Answer:** 11  
+   **Explanation:** The transcript states, “Coming January 11th.”
+
+6. According to the transcript, you do not have to be an __ to change how people see the world.  
+   **Answer:** advocate  
+   **Explanation:** He says, “You don't have to be an advocate to change the way in person sees the world.”
+
+---
+
+### Short Answer (6)
+
+1. What is the main goal of the podcast?  
+   **Answer:** To give listeners actionable insights on how to be a better human.  
+   **Explanation:** The host explains the podcast will offer “actionable insights on how to be a little less terrible as partners, listeners, allies, activists and all the other ways that we're human.”
+
+2. Name two roles the host mentions people can improve in.  
+   **Answer:** Partners and listeners.  
+   **Explanation:** The transcript lists “partners, listeners, allies, activists” as roles to improve.
+
+3. According to the transcript, what is necessary for a conversation to be effective?  
+   **Answer:** Both people must be open and share hopes, dreams, and emotions.  
+   **Explanation:** He says, “you have to be open, you have to get the other person to be open.”
+
+4. How does the host suggest you can influence others without being an advocate?  
+   **Answer:** By modeling your values in everyday actions.  
+   **Explanation:** He says, “It’s really about just modeling your values in your day‑to‑day actions.”
+
+5. What date is the podcast scheduled to begin?  
+   **Answer:** January 11th.  
+   **Explanation:** The transcript ends with “Coming January 11th.”
+
+6. What does the host mean by “put yourself in the drive seat”?  
+   **Answer:** Take control of your own progress and decide if your actions help or harm your goals.  
+   **Explanation:** He explains, “put yourself in the drive seat to say, is this helping or harming me in my quest to get through this?”

--- a/generated_questions_md/ReThinking_With_Adam_Grant_Trailer_questions.md
+++ b/generated_questions_md/ReThinking_With_Adam_Grant_Trailer_questions.md
@@ -1,0 +1,242 @@
+# Question Set: ReThinking_With_Adam_Grant_Trailer.txt
+
+## Beginner
+### Multiple Choice (8)
+
+1. Who is the host of the podcast?  
+   A. Lin‑Manuel Miranda  
+   B. Adam  
+   C. Mark Cuban  
+   D. Celeste Ing  
+   **Answer:** B. Adam  
+   **Explanation:** The transcript says, “It’s Adam here…”
+
+2. What is the name of the podcast?  
+   A. Work Life  
+   B. Rethinking with Adam Grand  
+   C. Rethinking with Adam  
+   D. Work Life with Adam  
+   **Answer:** B. Rethinking with Adam Grand  
+   **Explanation:** Adam says, “We’ve decided to call it rethinking with Adam Grand…”
+
+3. Which guest is a neuroscientist?  
+   A. Mark Cuban  
+   B. Shantelle Pratt  
+   C. Reese Witherspoon  
+   D. Saul Pro‑Mutter  
+   **Answer:** B. Shantelle Pratt  
+   **Explanation:** The transcript lists “neuroscientist Shantelle Pratt.”
+
+4. Which guest is an actor?  
+   A. Lin‑Manuel Miranda  
+   B. Reese Witherspoon  
+   C. Mark Cuban  
+   D. Celeste Ing  
+   **Answer:** B. Reese Witherspoon  
+   **Explanation:** The transcript names “Oscar‑winning actor and producer, Reese Witherspoon.”
+
+5. What is the goal of the conversations?  
+   A. To talk about sports  
+   B. To figure out what makes them tick  
+   C. To sell books  
+   D. To discuss politics  
+   **Answer:** B. To figure out what makes them tick  
+   **Explanation:** Adam says, “The goal is to figure out what makes them tick…”
+
+6. Which platform is NOT mentioned?  
+   A. Apple podcast  
+   B. Spotify  
+   C. YouTube  
+   D. Wherever you listen  
+   **Answer:** C. YouTube  
+   **Explanation:** Only Apple podcast, Spotify, and “wherever you listen” are mentioned.
+
+7. When will season six of Work Life come out?  
+   A. Next year  
+   B. Next month  
+   C. Next week  
+   D. Never  
+   **Answer:** A. Next year  
+   **Explanation:** Adam says, “season six of Work Life will still be coming out right here next year.”
+
+8. Who is the entrepreneur guest?  
+   A. Mark Cuban  
+   B. Saul Pro‑Mutter  
+   C. Lin‑Manuel Miranda  
+   D. Reese Witherspoon  
+   **Answer:** A. Mark Cuban  
+   **Explanation:** The transcript lists “entrepreneur Mark Cuban.”
+
+### Fill in the Blank (6)
+
+1. The podcast is called ____.  
+   **Answer:** Rethinking with Adam Grand  
+   **Explanation:** Adam says, “We’ve decided to call it rethinking with Adam Grand.”
+
+2. The host’s name is ____.  
+   **Answer:** Adam  
+   **Explanation:** The transcript begins, “It’s Adam here…”
+
+3. The show will feature conversations with entrepreneur ____.  
+   **Answer:** Mark Cuban  
+   **Explanation:** The list of guests includes “entrepreneur Mark Cuban.”
+
+4. The show will also feature Nobel laureate physicist ____.  
+   **Answer:** Saul Pro‑Mutter  
+   **Explanation:** The transcript names “Nobel laureate physicist Saul Pro‑Mutter.”
+
+5. The podcast is available on Apple podcast, Spotify, and ____.  
+   **Answer:** wherever you listen  
+   **Explanation:** Adam says, “Follow rethinking with Adam Grand, an Apple podcast, Spotify, or wherever you listen.”
+
+6. The goal is to figure out what makes them ____.  
+   **Answer:** tick  
+   **Explanation:** Adam states, “to figure out what makes them tick.”
+
+### Short Answer (6)
+
+1. What type of people does Adam talk to on the show?  
+   **Answer:** Thinkers, creators, doers, and leaders.  
+   **Explanation:** Adam says, “my favorite thinkers, creators, doers, and leaders.”
+
+2. What is the main aim of the conversations?  
+   **Answer:** To figure out what makes them tick and what they can teach about a life well lived.  
+   **Explanation:** The transcript explains this as the goal of the show.
+
+3. Name one of the guests mentioned.  
+   **Answer:** Lin‑Manuel Miranda (or any other listed guest).  
+   **Explanation:** The transcript lists several guests, including Lin‑Manuel Miranda.
+
+4. Which platform can you listen to the podcast on?  
+   **Answer:** Apple podcast, Spotify, or wherever you listen.  
+   **Explanation:** Adam lists these platforms as options.
+
+5. What season of Work Life is coming out next year?  
+   **Answer:** Season six.  
+   **Explanation:** Adam says, “season six of Work Life will still be coming out right here next year.”
+
+6. Who is the neuroscientist guest?  
+   **Answer:** Shantelle Pratt.  
+   **Explanation:** The transcript names “neuroscientist Shantelle Pratt.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. Who is the host of the podcast?  
+   A. Adam Grand  
+   B. Lin‑Manuel Miranda  
+   C. Mark Cuban  
+   D. Saul Pro‑Mutter  
+   **Answer:** A  
+   **Explanation:** The transcript says, “It’s Adam here…”
+
+2. What is the name of the podcast?  
+   A. Work Life  
+   B. Rethinking with Adam Grand  
+   C. Life Well Lived  
+   D. The Conversation  
+   **Answer:** B  
+   **Explanation:** Adam says, “We’ve decided to call it rethinking with Adam Grand…”
+
+3. Which of the following guests is NOT mentioned?  
+   A. Lin‑Manuel Miranda  
+   B. Renee Brown  
+   C. Elon Musk  
+   D. Alex Pondelt  
+   **Answer:** C  
+   **Explanation:** Elon Musk is not listed among the guests.
+
+4. What type of content did they start releasing last year?  
+   A. Music videos  
+   B. More conversations and debates  
+   C. Cooking shows  
+   D. Sports commentary  
+   **Answer:** B  
+   **Explanation:** Adam says, “we started releasing more conversations and debates…”
+
+5. Which platform is NOT mentioned as a place to listen?  
+   A. Apple Podcast  
+   B. Spotify  
+   C. YouTube  
+   D. wherever you listen  
+   **Answer:** C  
+   **Explanation:** The transcript lists Apple Podcast, Spotify, and “wherever you listen,” but not YouTube.
+
+6. Which guest is a neuroscientist?  
+   A. Mark Cuban  
+   B. Shantelle Pratt  
+   C. Saul Pro‑Mutter  
+   D. Reef’s Witherspoon  
+   **Answer:** B  
+   **Explanation:** Shantelle Pratt is described as a neuroscientist.
+
+7. Which guest is a Nobel laureate physicist?  
+   A. Mark Cuban  
+   B. Saul Pro‑Mutter  
+   C. Alex Pondelt  
+   D. Lin‑Manuel Miranda  
+   **Answer:** B  
+   **Explanation:** Saul Pro‑Mutter is called a Nobel laureate physicist.
+
+8. When will season six of Work Life be released?  
+   A. Next year  
+   B. This year  
+   C. In 2025  
+   D. Not mentioned  
+   **Answer:** A  
+   **Explanation:** Adam says, “season six of Work Life will still be coming out right here next year.”
+
+### Fill in the Blank (6)
+
+1. The podcast is called ____.  
+   **Answer:** Rethinking with Adam Grand  
+   **Explanation:** The transcript states this exact title.
+
+2. The host is ____.  
+   **Answer:** Adam Grand  
+   **Explanation:** Adam introduces himself as “Adam here.”
+
+3. They started releasing more conversations and debates with ____.  
+   **Answer:** my favorite thinkers, creators, doers, and leaders  
+   **Explanation:** Adam lists these categories in the transcript.
+
+4. The guests include entrepreneur ____.  
+   **Answer:** Mark Cuban  
+   **Explanation:** Mark Cuban is named as an entrepreneur.
+
+5. The season six of Work Life will be coming out right ____.  
+   **Answer:** here  
+   **Explanation:** Adam says, “right here next year.”
+
+6. The podcast can be followed on ____.  
+   **Answer:** Apple podcast, Spotify, or wherever you listen  
+   **Explanation:** These platforms are mentioned at the end of the transcript.
+
+### Short Answer (6)
+
+1. What is the main goal of the podcast?  
+   **Answer:** To figure out what makes guests tick and what they can teach us about a life well lived.  
+   **Explanation:** Adam says, “the goal is to figure out what makes them tick and what they can teach us about a life well lived.”
+
+2. Name two guests mentioned in the transcript.  
+   **Answer:** Lin‑Manuel Miranda and Renee Brown (any two from the list are acceptable).  
+   **Explanation:** Both are listed among the guests.
+
+3. What type of episodes will be released regularly?  
+   **Answer:** Regular episodes all year round.  
+   **Explanation:** Adam states, “Regular episodes all year round.”
+
+4. Who is the Oscar‑winning actor and producer mentioned?  
+   **Answer:** Reef’s Witherspoon.  
+   **Explanation:** The transcript refers to “Oscar‑winning actor and producer, Reef’s Witherspoon.”
+
+5. Which guest is a death‑defying rock climber?  
+   **Answer:** Alex Pondelt.  
+   **Explanation:** He is described as a death‑defying rock climber.
+
+6. How does Adam describe his pull for the podcast’s name?  
+   **Answer:** It’s been the pull from him.  
+   **Explanation:** Adam says, “because that’s been the pull from me.”

--- a/generated_questions_md/TED_Business_Trailer_questions.md
+++ b/generated_questions_md/TED_Business_Trailer_questions.md
@@ -1,0 +1,247 @@
+# Question Set: TED_Business_Trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. **Who is the new host of the podcast?**  
+   A. Medupa Akinola  
+   B. John Smith  
+   C. Sarah Lee  
+   D. Alex Brown  
+   **Answer:** A  
+   **Explanation:** The transcript says, “That’s me, Medupa Akinola, a professor …”
+
+2. **Where does Medupa Akinola teach?**  
+   A. Harvard University  
+   B. Columbia Business School  
+   C. Stanford University  
+   D. MIT  
+   **Answer:** B  
+   **Explanation:** He is described as “a professor of management at Columbia Business School.”
+
+3. **When will the new talks start?**  
+   A. October 12th  
+   B. November 1st  
+   C. September 30th  
+   D. December 5th  
+   **Answer:** A  
+   **Explanation:** The transcript states, “Starting on October 12th…”
+
+4. **What is the main focus of the new talks?**  
+   A. Sports  
+   B. Business  
+   C. Cooking  
+   D. Music  
+   **Answer:** B  
+   **Explanation:** The talks are “produced for audio that all focus on business.”
+
+5. **Which of these topics is mentioned in the transcript?**  
+   A. Micro management  
+   B. Gardening  
+   C. Painting  
+   D. Dancing  
+   **Answer:** A  
+   **Explanation:** One topic listed is “curing micro management.”
+
+6. **What will the host share in each talk?**  
+   A. Recipes  
+   B. Insight and nugget  
+   C. Songs  
+   D. Travel tips  
+   **Answer:** B  
+   **Explanation:** He says, “I’ll be sharing a little insight and nugget for you…”
+
+7. **Where is the Center for Leadership and Ethics located?**  
+   A. New York  
+   B. San Francisco  
+   C. Chicago  
+   D. Boston  
+   **Answer:** B  
+   **Explanation:** He is the director of the “San Francisco Bernstein Company Center for Leadership and Ethics.”
+
+8. **What should listeners do to follow the new episodes?**  
+   A. Watch the feed  
+   B. Play a video  
+   C. Read a book  
+   D. Go to a museum  
+   **Answer:** A  
+   **Explanation:** He says, “Watch this feed and stay tuned…”
+
+### Fill in the Blank (6)
+
+1. The podcast is changing and will have new talks produced for **audio**.  
+   **Answer:** audio  
+   **Explanation:** The transcript says “produced for audio.”
+
+2. The host is Medupa Akinola, a professor of **management** at Columbia Business School.  
+   **Answer:** management  
+   **Explanation:** He is described as “a professor of management.”
+
+3. The talks will start on **October 12th**.  
+   **Answer:** October 12th  
+   **Explanation:** The transcript gives the exact date.
+
+4. One topic is curing **micro** management.  
+   **Answer:** micro  
+   **Explanation:** The transcript lists “curing micro management.”
+
+5. The host will share a little **insight** for you.  
+   **Answer:** insight  
+   **Explanation:** He says he will share “a little insight and nugget.”
+
+6. The host wants you to stay **tuned**.  
+   **Answer:** tuned  
+   **Explanation:** He says, “stay tuned for our first new episode.”
+
+### Short Answer (6)
+
+1. **Who is the new host?**  
+   **Answer:** Medupa Akinola  
+   **Explanation:** The transcript introduces him as “That’s me, Medupa Akinola.”
+
+2. **What is Medupa’s job title at Columbia?**  
+   **Answer:** Professor of management  
+   **Explanation:** He is described as “a professor of management at Columbia Business School.”
+
+3. **What is the name of the center he directs?**  
+   **Answer:** San Francisco Bernstein Company Center for Leadership and Ethics  
+   **Explanation:** He says he is the director of that center.
+
+4. **When will the first new episode be released?**  
+   **Answer:** October 12th  
+   **Explanation:** The transcript states the start date.
+
+5. **Name one topic covered in the talks.**  
+   **Answer:** Setting and reaching loftiest goals (or curing micro management, etc.)  
+   **Explanation:** The transcript lists several topics, including “setting and reaching the loftiest goals.”
+
+6. **What does the host want listeners to do?**  
+   **Answer:** Watch the feed and stay tuned  
+   **Explanation:** He ends with, “Watch this feed and stay tuned for our first new episode.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. Who is the new host of the Ted Business Podcast?  
+   A. Medupa Akinola  
+   B. Ted Business  
+   C. Columbia Business School  
+   D. San Francisco Bernstein Company  
+   **Answer:** A  
+   **Explanation:** The transcript says, “That’s me, Medupa Akinola, a professor of management at Columbia Business School…”
+
+2. When does the new schedule of talks begin?  
+   A. October 12th  
+   B. November 1st  
+   C. September 30th  
+   D. December 1st  
+   **Answer:** A  
+   **Explanation:** The host states, “Starting on October 12th, we’ll be presenting a new talk every week…”
+
+3. What format are the new talks produced in?  
+   A. Visual presentations  
+   B. Audio talks  
+   C. Written articles  
+   D. Live seminars  
+   **Answer:** B  
+   **Explanation:** The transcript mentions “produced for audio that all focus on business.”
+
+4. Which of the following topics is NOT mentioned in the transcript?  
+   A. Setting goals  
+   B. Micro management  
+   C. Marketing strategies  
+   D. Unconscious bias  
+   **Answer:** C  
+   **Explanation:** The topics listed are goals, micro management, unconscious bias, and mindset; marketing strategies are not mentioned.
+
+5. The host is a professor at which institution?  
+   A. Harvard Business School  
+   B. Columbia Business School  
+   C. Stanford Graduate School of Business  
+   D. MIT Sloan  
+   **Answer:** B  
+   **Explanation:** The transcript says, “a professor of management at Columbia Business School.”
+
+6. The host also directs which center?  
+   A. Center for Innovation  
+   B. Center for Leadership and Ethics  
+   C. Center for Marketing  
+   D. Center for Finance  
+   **Answer:** B  
+   **Explanation:** The transcript states, “director of the San Francisco Bernstein Company Center for Leadership and Ethics.”
+
+7. How often will a new talk be released?  
+   A. Daily  
+   B. Weekly  
+   C. Monthly  
+   D. Biweekly  
+   **Answer:** B  
+   **Explanation:** The host says, “we’ll be presenting a new talk every week.”
+
+8. What does the host promise to share with each new talk?  
+   A. A new song  
+   B. A cooking recipe  
+   C. An insight and nugget  
+   D. A movie recommendation  
+   **Answer:** C  
+   **Explanation:** The transcript says, “I’ll be sharing a little insight and nugget for you…”
+
+---
+
+### Fill in the Blank (6)
+
+1. The podcast is changing to focus on ________ talks.  
+   **Answer:** business  
+   **Explanation:** The transcript says, “all focus on business.”
+
+2. The new host is Medupa Akinola, a professor of ________ at Columbia Business School.  
+   **Answer:** management  
+   **Explanation:** The transcript identifies her role as a professor of management.
+
+3. The new schedule starts on ________ 12th.  
+   **Answer:** October  
+   **Explanation:** The host says, “Starting on October 12th…”
+
+4. Topics include setting and reaching the ________ goals.  
+   **Answer:** loftiest  
+   **Explanation:** The transcript lists “the loftiest goals.”
+
+5. The host will share a little insight and ________ for you.  
+   **Answer:** nugget  
+   **Explanation:** The host mentions “a little insight and nugget.”
+
+6. The host is also director of the San Francisco ________ Company Center for Leadership and Ethics.  
+   **Answer:** Bernstein  
+   **Explanation:** The transcript names the center as “San Francisco Bernstein Company Center…”
+
+---
+
+### Short Answer (6)
+
+1. **Question:** What is the name of the podcast?  
+   **Answer:** Ted Business Podcast  
+   **Explanation:** The transcript opens with “Hey everyone, the Ted Business Podcast is changing.”
+
+2. **Question:** Who is the new host?  
+   **Answer:** Medupa Akinola  
+   **Explanation:** The host introduces herself as “That’s me, Medupa Akinola…”
+
+3. **Question:** What is the host’s role at Columbia Business School?  
+   **Answer:** Professor of management  
+   **Explanation:** The transcript states she is “a professor of management at Columbia Business School.”
+
+4. **Question:** When will the first new episode be released?  
+   **Answer:** October 12th  
+   **Explanation:** The host says, “Starting on October 12th…”
+
+5. **Question:** Name one topic that will be covered in the new talks.  
+   **Answer:** Curing micro management (or disrupting unconscious bias, etc.)  
+   **Explanation:** The transcript lists several topics, including “curing micro management” and “disrupting unconscious bias.”
+
+6. **Question:** What does the host ask listeners to do to stay updated?  
+   **Answer:** Watch the feed and stay tuned  
+   **Explanation:** The host ends with, “Watch this feed and stay tuned for our first new episode.”

--- a/generated_questions_md/TED_Interview_S01E00_trailer_questions.md
+++ b/generated_questions_md/TED_Interview_S01E00_trailer_questions.md
@@ -1,0 +1,249 @@
+# Question Set: TED_Interview_S01E00_trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. **Who is speaking in the transcript?**  
+   A. Chris Anderson  
+   B. TED  
+   C. Apple  
+   D. Unknown  
+   **Answer:** A  
+   **Explanation:** The speaker says, “Hi everyone, I'm Chris Anderson…”
+
+2. **What does TED focus on?**  
+   A. Power of ideas  
+   B. Movies  
+   C. Sports  
+   D. Food  
+   **Answer:** A  
+   **Explanation:** The speaker says TED is “obsessed with the power of ideas.”
+
+3. **According to the speaker, ideas are a pattern of information that changes your ___?**  
+   A. taste  
+   B. world view  
+   C. shoes  
+   D. phone  
+   **Answer:** B  
+   **Explanation:** The transcript says ideas “change how you see the world.”
+
+4. **What does the speaker ask people to think about when they see something?**  
+   A. Do you walk away or stop?  
+   B. Do you eat?  
+   C. Do you sleep?  
+   D. Do you drive?  
+   **Answer:** A  
+   **Explanation:** He asks, “when you see something, what do you do?”
+
+5. **How long does it sometimes take for ideas to develop?**  
+   A. Longer than 18 minutes  
+   B. 5 minutes  
+   C. 1 hour  
+   D. 30 seconds  
+   **Answer:** A  
+   **Explanation:** He says ideas “take longer than 18 minutes.”
+
+6. **When will the new podcast start dropping?**  
+   A. Oct 16th  
+   B. Jan 1st  
+   C. Dec 25th  
+   D. Feb 14th  
+   **Answer:** A  
+   **Explanation:** The transcript says episodes start “October 16th.”
+
+7. **What is the name of the new podcast?**  
+   A. The Ted Interview  
+   B. TED Talks  
+   C. The Idea Show  
+   D. None  
+   **Answer:** A  
+   **Explanation:** He says, “a new podcast called The Ted Interview.”
+
+8. **What does the speaker say about overconfidence?**  
+   A. Enemy of good thinking  
+   B. Good thing  
+   C. Not mentioned  
+   D. None  
+   **Answer:** A  
+   **Explanation:** He says, “Overconfidence is really the enemy of good thinking.”
+
+---
+
+### Fill in the Blank (6)
+
+1. The speaker says ideas are a pattern of information that gets inside your ____.  
+   **Answer:** head  
+   **Explanation:** The transcript: “pattern of information that gets inside your head.”
+
+2. The new podcast will start dropping weekly on ____.  
+   **Answer:** October 16th  
+   **Explanation:** “starting October 16th.”
+
+3. The speaker says creativity comes in ____, not lightning strikes.  
+   **Answer:** whispers  
+   **Explanation:** “creativity comes in whispers.”
+
+4. The speaker says overconfidence is the __ of good thinking.  
+   **Answer:** enemy  
+   **Explanation:** “Overconfidence is really the enemy of good thinking.”
+
+5. The speaker says ideas need to be critiqued, played with, and ____.  
+   **Answer:** rated  
+   **Explanation:** “They want to be critiqued, played with, it’s rated on.”
+
+6. The speaker says the history of human achievement shows people did remarkable things from __ beginnings.  
+   **Answer:** improbable  
+   **Explanation:** “from very improbable beginnings.”
+
+---
+
+### Short Answer (6)
+
+1. **Who runs TED?**  
+   **Answer:** Chris Anderson  
+   **Explanation:** He introduces himself as “the guy lucky enough to run TED.”
+
+2. **What is the main focus of TED?**  
+   **Answer:** The power of ideas  
+   **Explanation:** He says TED is “obsessed with the power of ideas.”
+
+3. **How do ideas change us, according to the speaker?**  
+   **Answer:** They change how you see the world  
+   **Explanation:** He describes ideas as changing your view of the world.
+
+4. **What does the speaker suggest we do when we see something?**  
+   **Answer:** Stop and slow down, say “I’m complicit in this.”  
+   **Explanation:** He asks if we “stop and slow down and says, I'm complicit in this?”
+
+5. **When will the new podcast episodes be released?**  
+   **Answer:** Weekly starting October 16th  
+   **Explanation:** “Our episodes drop weekly starting October 16th.”
+
+6. **Where can you subscribe to the podcast?**  
+   **Answer:** Apple Podcasts or wherever you listen  
+   **Explanation:** He says, “Subscribe for free on Apple podcasts or wherever you listen.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. Who is speaking in the transcript?  
+   A. A TED speaker  
+   B. Chris Anderson  
+   C. Apple Podcast host  
+   D. An unknown narrator  
+   **Answer:** B  
+   **Explanation:** The speaker introduces himself as “Chris Anderson, the guy lucky enough to run Ted.”
+
+2. According to the speaker, what is the effect of ideas on us?  
+   A. They are boring patterns.  
+   B. They change how we see the world.  
+   C. They keep us asleep.  
+   D. They make us angry.  
+   **Answer:** B  
+   **Explanation:** He says ideas “are a pattern of information that gets inside your head and it changes how you see the world.”
+
+3. What does the speaker say about overconfidence?  
+   A. It is helpful.  
+   B. It is the enemy of good thinking.  
+   C. It is irrelevant.  
+   D. It is a sign of intelligence.  
+   **Answer:** B  
+   **Explanation:** He warns, “Don’t trust yourself too much. Overconfidence is really the enemy of good thinking.”
+
+4. When will the new podcast episodes start dropping?  
+   A. October 1st  
+   B. October 16th  
+   C. November 1st  
+   D. December 1st  
+   **Answer:** B  
+   **Explanation:** He states, “Our episodes drop weekly starting October 16th.”
+
+5. How does the speaker describe the origin of creativity?  
+   A. Lightning strikes  
+   B. Whispers  
+   C. Sudden explosions  
+   D. Random thoughts  
+   **Answer:** B  
+   **Explanation:** He says, “I think everybody thinks that creativity comes in lightning strikes, but I think it comes in whispers.”
+
+6. What is the name of the new podcast?  
+   A. TED Talks  
+   B. The Ted Interview  
+   C. Ideas Unleashed  
+   D. Creative Minds  
+   **Answer:** B  
+   **Explanation:** He announces, “We’re releasing a new podcast called The Ted Interview.”
+
+7. What does the speaker say about how ideas are formed?  
+   A. They land perfectly formed.  
+   B. They need to be critiqued and played with.  
+   C. They are always simple.  
+   D. They are random.  
+   **Answer:** B  
+   **Explanation:** He explains, “Ideas don’t just land perfectly formed. They want to be critiqued, played with…”
+
+8. According to the transcript, what has been the history of human achievement?  
+   A. People have done nothing remarkable.  
+   B. People have done remarkable things from improbable beginnings.  
+   C. People have always been predictable.  
+   D. People have never changed the world.  
+   **Answer:** B  
+   **Explanation:** He says, “The history of human achievement is that people have done remarkable things from very improbable beginnings.”
+
+---
+
+### Fill in the Blank (6)
+
+1. Chris Anderson says ideas are a pattern of information that gets inside your head and ____.  
+   **Answer:** changes how you see the world  
+   **Explanation:** The transcript states this exact phrase.
+
+2. He says the most important questions in human life are questions we have to be able to ____.  
+   **Answer:** talk about  
+   **Explanation:** The speaker mentions this directly.
+
+3. He says creativity comes in ____, not lightning strikes.  
+   **Answer:** whispers  
+   **Explanation:** He contrasts lightning strikes with whispers.
+
+4. He says episodes drop weekly starting ____.  
+   **Answer:** October 16th  
+   **Explanation:** The release date is given.
+
+5. He says overconfidence is the enemy of ____.  
+   **Answer:** good thinking  
+   **Explanation:** The transcript warns about overconfidence.
+
+6. He says ideas want to be critiqued, played with, and sometimes that takes longer than __ minutes.  
+   **Answer:** 18  
+   **Explanation:** He mentions “longer than 18 minutes.”
+
+---
+
+### Short Answer (6)
+
+1. **What role does Chris Anderson have at TED?**  
+   **Answer:** He runs TED.  
+   **Explanation:** He introduces himself as “the guy lucky enough to run Ted.”
+
+2. **What does the speaker say about the process of ideas?**  
+   **Answer:** Ideas don’t land perfectly formed; they need to be critiqued, played with, and may take longer than 18 minutes.  
+   **Explanation:** This is described in the transcript.
+
+3. **What is the main theme of the new podcast?**  
+   **Answer:** Exploring ideas, creativity, and human achievement through conversations with TED speakers.  
+   **Explanation:** He talks about inviting speakers, encouraging deeper exploration, and releasing the podcast.
+
+4. **How does Chris describe the nature of creativity?**  
+   **Answer:** Creativity comes in whispers that can grow thunderous over time if you are patient.  
+   **Explanation:** He contrasts lightning strikes with whispers and mentions growth over time.
+
+5. **What advice does he give about trusting yourself?**  
+   **Answer:** Don’t trust yourself too much; overconfidence is the enemy of good thinking.  
+   **Explanation:** This warning is explicitly stated.
+
+6. **When and

--- a/generated_questions_md/Your_Undivided_Attention_Trailer_questions.md
+++ b/generated_questions_md/Your_Undivided_Attention_Trailer_questions.md
@@ -1,0 +1,239 @@
+# Question Set: Your_Undivided_Attention_Trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. Who is the speaker in the transcript?  
+   A. A teacher  
+   B. Tristan Harris  
+   C. A musician  
+   D. A chef  
+   **Answer:** B  
+   **Explanation:** The speaker says, “I’m Tristan Harris…”
+
+2. What did Tristan Harris do at Google?  
+   A. Cooked food  
+   B. Designed ethics  
+   C. Played sports  
+   D. Sang songs  
+   **Answer:** B  
+   **Explanation:** He says, “a former design ethicist at Google.”
+
+3. What is the name of the podcast they are launching?  
+   A. Tech Talk  
+   B. Your Undivided Attention  
+   C. Future Tech  
+   D. Daily News  
+   **Answer:** B  
+   **Explanation:** The transcript mentions, “we’re launching a new podcast called Your Undivided Attention.”
+
+4. When will the podcast start?  
+   A. January 1st  
+   B. June 10th  
+   C. December 25th  
+   D. July 4th  
+   **Answer:** B  
+   **Explanation:** It says, “Our podcast premieres on June 10th.”
+
+5. What does “human downgrading” mean in the text?  
+   A. People learning new skills  
+   B. Technology making people less good at thinking  
+   C. Animals becoming smarter  
+   D. Plants growing faster  
+   **Answer:** B  
+   **Explanation:** The speaker says it “dominates increasingly different parts of human nature.”
+
+6. Who helped build the open web at Mizzilla?  
+   A. Tristan Harris  
+   B. Eza Raskin  
+   C. A teacher  
+   D. A musician  
+   **Answer:** B  
+   **Explanation:** He says, “I helped build the open web at Mizzilla…”
+
+7. What is the “infinite scroll” mentioned?  
+   A. A type of dance  
+   B. A way to keep scrolling on a screen  
+   C. A new book  
+   D. A cooking recipe  
+   **Answer:** B  
+   **Explanation:** It is a feature on websites that lets users scroll endlessly.
+
+8. According to the transcript, what is missing in Silicon Valley?  
+   A. More computers  
+   B. Sophistication about human nature  
+   C. More coffee  
+   D. Better cars  
+   **Answer:** B  
+   **Explanation:** The speaker says, “what’s been missing isn’t more tech or better tech. The thing that’s missing is sophistication about human nature.”
+
+### Fill in the Blank (6)
+
+1. The speaker says technology is a force that pushes our culture in a very ___ direction.  
+   **Answer:** specific  
+   **Explanation:** The transcript says, “pushing our culture in a very specific direction.”
+
+2. Tristan Harris is a former ___ ethicist at Google.  
+   **Answer:** design  
+   **Explanation:** He says, “a former design ethicist at Google.”
+
+3. Eza Raskin helped build the ___ web at Mizzilla.  
+   **Answer:** open  
+   **Explanation:** He says, “helped build the open web at Mizzilla.”
+
+4. The podcast will talk to experts on ___ development.  
+   **Answer:** children’s  
+   **Explanation:** The transcript lists “experts on children’s development.”
+
+5. The father of sociobiology said we have paleolithic emotions, medieval institutions, and ___ technology.  
+   **Answer:** godlike  
+   **Explanation:** The transcript says, “godlike technology.”
+
+6. The podcast will be available on Apple Podcasts, Google Podcasts, and ___ you may listen.  
+   **Answer:** wherever  
+   **Explanation:** It says, “or wherever you may listen.”
+
+### Short Answer (6)
+
+1. What is the main problem the speakers want to solve?  
+   **Answer:** The way technology pulls people apart and makes them feel negative emotions.  
+   **Explanation:** They talk about technology hijacking attention, causing envy, hatred, isolation, and division.
+
+2. Who are the speakers?  
+   **Answer:** Tristan Harris and Eza Raskin.  
+   **Explanation:** They introduce themselves at the start of the transcript.
+
+3. What kind of experts will they invite to the podcast?  
+   **Answer:** Experts on human nature, magicians, hypnotists, evolutionary biologists, and others.  
+   **Explanation:** The transcript lists these groups as guests.
+
+4. Why do the speakers compare technology’s effect to climate change?  
+   **Answer:** Because it can lead to a bad future if not fixed.  
+   **Explanation:** They say the result will be catastrophic, like climate change.
+
+5. What does “infinite scroll” do?  
+   **Answer:** It lets you keep scrolling on a screen without stopping.  
+   **Explanation:** It is a feature that keeps showing new content as you scroll.
+
+6. How can people help change technology’s direction?  
+   **Answer:** By learning more about human nature and using technology wisely.  
+   **Explanation:** The speakers say we need to “embrace our paleolithic emotions, uplift our medieval institutions, and give us the wisdom to wield our godlike technology.”
+
+---
+
+## Intermediate
+### Multiple Choice (8)
+1. Who is Tristan Harris?  
+A. Former design ethicist at Google  
+B. Founder of Mizzilla  
+C. Inventor of infinite scroll  
+D. Podcast host  
+**Answer:** A  
+**Explanation:** The transcript states he is a former design ethicist at Google.
+
+2. What did Eza Raskin invent?  
+A. Infinite scroll  
+B. Open web  
+C. Instagram  
+D. Podcast  
+**Answer:** A  
+**Explanation:** He is credited with inventing the infinite scroll.
+
+3. When does the podcast premiere?  
+A. June 10th  
+B. July 1st  
+C. May 15th  
+D. August 20th  
+**Answer:** A  
+**Explanation:** The launch date is given as June 10th.
+
+4. What is the main goal of the podcast?  
+A. Reimagine the technology ecosystem  
+B. Promote Instagram  
+C. Sell products  
+D. Discuss fashion trends  
+**Answer:** A  
+**Explanation:** The podcast aims to reimagine the tech ecosystem.
+
+5. Which expert will NOT be featured?  
+A. Magicians  
+B. Hypnotists  
+C. Astrophysicists  
+D. Evolutionary biologists  
+**Answer:** C  
+**Explanation:** Astrophysicists are not mentioned among the invited experts.
+
+6. According to the transcript, what is “human downgrading”?  
+A. Climate change of culture  
+B. New tech trend  
+C. Economic recession  
+D. Health crisis  
+**Answer:** A  
+**Explanation:** It is described as the climate change of culture.
+
+7. How many Silicon Valley people need to change to solve the problems?  
+A. A thousand  
+B. Ten thousand  
+C. One hundred  
+D. None  
+**Answer:** A  
+**Explanation:** Only a thousand people need to change.
+
+8. What does the father of sociobiology say about humanity?  
+A. Paleolithic emotions, medieval institutions, godlike technology  
+B. Need more tech  
+C. Society is perfect  
+D. Humans are rational  
+**Answer:** A  
+**Explanation:** That is the quote from the transcript.
+
+### Fill in the Blank (6)
+1. Tristan Harris is a former design ethicist at ______.  
+**Answer:** Google  
+**Explanation:** The transcript identifies him as such.
+
+2. Eza Raskin helped build the open web at ______.  
+**Answer:** Mizzilla  
+**Explanation:** He is credited with building the open web at Mizzilla.
+
+3. The podcast is called ______.  
+**Answer:** Your Undivided Attention  
+**Explanation:** That is the title mentioned.
+
+4. The podcast will flip the race from a race to the bottom to a race to the ______.  
+**Answer:** top  
+**Explanation:** The goal is to move to a race to the top.
+
+5. The father of sociobiology said we need to embrace our paleolithic emotions, uplift our medieval institutions, and give us the wisdom to wield our ______ technology.  
+**Answer:** godlike  
+**Explanation:** The quote uses “godlike technology.”
+
+6. The podcast will be available on Apple Podcasts, Google Podcasts, and ______.  
+**Answer:** wherever you may listen  
+**Explanation:** The transcript says “or wherever you may listen.”
+
+### Short Answer (6)
+1. What is the main problem the speakers identify with technology?  
+**Answer:** Technology hijacks attention, shapes thoughts, stokes envy, hatred, isolation, division, and downgrades human nature.  
+**Explanation:** These issues are listed in the transcript.
+
+2. Who are the co‑founders of the Center for Humane Technology?  
+**Answer:** Tristan Harris and Eza Raskin.  
+**Explanation:** They are introduced as co‑founders.
+
+3. What is the “infinite scroll” and who invented it?  
+**Answer:** A design feature that loads content endlessly; invented by Eza Raskin.  
+**Explanation:** The transcript credits him with the invention.
+
+4. What does “human downgrading” refer to?  
+**Answer:** The process where technology increasingly dominates parts of human nature, leading to more divisive thoughts and emotions, likened to climate change of culture.  
+**Explanation:** The transcript explains this concept.
+
+5. Name two types of experts the podcast plans to interview.  
+**Answer:** Magicians and hypnotists (or evolutionary biologists, etc.).  
+**Explanation:** These experts are mentioned among the planned guests.
+
+6. According to the transcript, what is missing in Silicon Valley’s approach to technology?  
+**Answer:** Sophistication about human nature.  
+**Explanation:** The transcript states that what’s missing is sophistication about human nature.

--- a/generated_questions_md/ZigZag_S5_E00_TRAILER_questions.md
+++ b/generated_questions_md/ZigZag_S5_E00_TRAILER_questions.md
@@ -1,0 +1,205 @@
+# Question Set: ZigZag_S5_E00_TRAILER.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. Who is the host of the podcast?  
+   A. Manou Shazamaroti  
+   B. Ted Radio Hour  
+   C. NPR  
+   D. Zigzag  
+   **Answer:** A  
+   **Explanation:** The transcript says, “I’m Manou Shazamaroti and Zigzag is the business show…”
+
+2. What is the name of the podcast?  
+   A. Ted Radio Hour  
+   B. Zigzag  
+   C. The Business Show  
+   D. The Podcast  
+   **Answer:** B  
+   **Explanation:** The host introduces it as “Zigzag is the business show…”
+
+3. When did the host debut the new role?  
+   A. Before lockdown  
+   B. After lockdown  
+   C. Same day as lockdown  
+   D. A month later  
+   **Answer:** C  
+   **Explanation:** The transcript says, “I debuted my new role on the radio the same day the country went into lockdown…”
+
+4. What did the host say about the economy?  
+   A. It improved  
+   B. It stayed the same  
+   C. It got worse  
+   D. It was irrelevant  
+   **Answer:** C  
+   **Explanation:** The host says, “the economy kept getting worse.”
+
+5. What does the host want to see?  
+   A. More cupcakes  
+   B. People changing lives  
+   C. More businesses  
+   D. Less people  
+   **Answer:** B  
+   **Explanation:** The host says, “I want to see people who are changing their own lives by changing the lives of others.”
+
+6. Who does the host identify as?  
+   A. White woman  
+   B. Black gay woman  
+   C. Asian man  
+   D. Hispanic teacher  
+   **Answer:** B  
+   **Explanation:** The host says, “I identify as a black gay woman…”
+
+7. What are the three self‑help remedies mentioned?  
+   A. Meditation, yoga, reading  
+   B. Well‑buterin, marathon running, sex  
+   C. Running, dancing, cooking  
+   D. None  
+   **Answer:** B  
+   **Explanation:** The host lists, “my three self‑help remedies are well‑buterin, marathon running, and sex.”
+
+8. When will the new season start?  
+   A. July 23rd  
+   B. August 1st  
+   C. June 15th  
+   D. September 10th  
+   **Answer:** A  
+   **Explanation:** The transcript says, “Thursdays this summer starting July 23rd…”
+
+---
+
+### Fill in the Blank (6)
+
+1. The host says the podcast is part of the **Ted** Family of Podcasts.  
+   **Answer:** Ted  
+   **Explanation:** The transcript states, “I’m back as part of the Ted Family of Podcasts.”
+
+2. The host mentions “six very unusual dynamos” will be on season **five**.  
+   **Answer:** five  
+   **Explanation:** The host says, “on season five, you’ll hear how six very unusual dynamos…”
+
+3. The host says they love having a **cupcake** delivered to them.  
+   **Answer:** cupcake  
+   **Explanation:** The host says, “I love the fact that I can have a cupcake delivered to me.”
+
+4. The host says they want to see people who are changing their own lives by changing the lives of **others**.  
+   **Answer:** others  
+   **Explanation:** The host says, “I want to see people who are changing their own lives by changing the lives of others.”
+
+5. The host says they identify as a **black** gay woman.  
+   **Answer:** black  
+   **Explanation:** The host says, “I identify as a black gay woman…”
+
+6. The host says they will start on Thursdays this summer starting July **23rd**.  
+   **Answer:** 23rd  
+   **Explanation:** The transcript says, “Thursdays this summer starting July 23rd…”
+
+---
+
+### Short Answer (6)
+
+1. **Question:** What is the host’s name?  
+   **Answer:** Manou Shazamaroti  
+   **Explanation:** The transcript introduces the host as “I’m Manou Shazamaroti…”
+
+2. **Question:** What is the host’s new role?  
+   **Answer:** Host of the Zigzag podcast  
+   **Explanation:** The host says, “I debuted my new role on the radio… Zigzag is the business show…”
+
+3. **Question:** What happened to the host’s kids?  
+   **Answer:** They stopped going to school  
+   **Explanation:** The transcript says, “my kids stopped going to school.”
+
+4. **Question:** What did the pandemic do to the host’s other business?  
+   **Answer:** It put it on hold  
+   **Explanation:** The host says, “the pandemic put the cabash on my other business venture.”
+
+5. **Question:** What does the host want to help the country do?  
+   **Answer:** Reckon with its past and build a better future  
+   **Explanation:** The host says, “I am trying to figure out how to do my part to help this country reckon with its past and build a better future.”
+
+6. **Question:** What are the three self‑help remedies mentioned?  
+   **Answer:** Well‑buterin, marathon running, and sex  
+   **Explanation:** The host lists, “my three self‑help remedies are well‑buterin, marathon running, and sex.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. **What event coincided with the speaker's debut on the radio?**  
+   A. Election  
+   B. Lockdown  
+   C. New year  
+   D. Summer festival  
+   **Answer:** B  
+   **Explanation:** The transcript says the debut happened “the same day the country went into lockdown.”
+
+2. **Which podcast family does “Zigzag” belong to?**  
+   A. TED Family of Podcasts  
+   B. NPR Family  
+   C. Radio Hour  
+   D. None of the above  
+   **Answer:** A  
+   **Explanation:** The speaker says “Zigzag is the business show about being human… part of the Ted Family of Podcasts.”
+
+3. **What are the three self‑help remedies mentioned?**  
+   A. Meditation, yoga, reading  
+   B. Well‑buterin, marathon running, sex  
+   C. Diet, exercise, sleep  
+   D. Therapy, journaling, music  
+   **Answer:** B  
+   **Explanation:** The transcript lists “well‑buterin, marathon running, and sex.”
+
+4. **When does the new season of the podcast start?**  
+   A. July 23rd  
+   B. August 1st  
+   C. June 15th  
+   D. September 5th  
+   **Answer:** A  
+   **Explanation:** The speaker says “Thursdays this summer starting July 23rd.”
+
+5. **How does the speaker identify?**  
+   A. Black gay woman  
+   B. White heterosexual man  
+   C. Asian transgender woman  
+   D. Hispanic bisexual man  
+   **Answer:** A  
+   **Explanation:** The transcript states “I identify as a black gay woman.”
+
+6. **What is the main theme of the podcast?**  
+   A. Investing in tech  
+   B. Being human  
+   C. Cooking recipes  
+   D. Travel tips  
+   **Answer:** B  
+   **Explanation:** The speaker describes “Zigzag is the business show about being human.”
+
+7. **How many dynamos will be featured in season five?**  
+   A. Four  
+   B. Five  
+   C. Six  
+   D. Seven  
+   **Answer:** C  
+   **Explanation:** The transcript says “six very unusual dynamos.”
+
+8. **What is the speaker’s opinion about cupcake delivery companies?**  
+   A. They are essential  
+   B. They are unnecessary  
+   C. They are the future  
+   D. They are dangerous  
+   **Answer:** B  
+   **Explanation:** The speaker says “I don’t need to see another cupcake delivery company.”
+
+---
+
+### Fill in the Blank (6)
+
+1. The speaker says they “debuted my new role on the radio the same day the country went into ____.**  
+   **Answer:** lockdown  
+   **Explanation:** The transcript explicitly mentions the lockdown.
+
+2. They mention “the pandemic put the ____ on my other

--- a/generated_questions_md/fixable_trailer_questions.md
+++ b/generated_questions_md/fixable_trailer_questions.md
@@ -1,0 +1,246 @@
+# Question Set: fixable_trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. **Who is Ann Morris?**  
+   A. A teacher  
+   B. A company builder  
+   C. A singer  
+   D. A chef  
+   **Answer:** B  
+   **Explanation:** The transcript says, “My name is Ann Morris. I'm a company builder and a leadership coach.”
+
+2. **Who is Frances Fry?**  
+   A. Author  
+   B. Doctor  
+   C. Painter  
+   D. Lawyer  
+   **Answer:** A  
+   **Explanation:** The transcript says, “I'm Frances Fry. I'm an author and a Harvard Business School professor.”
+
+3. **What do Ann and Frances do together?**  
+   A. Cook food  
+   B. Build businesses  
+   C. Drive cars  
+   D. Write songs  
+   **Answer:** B  
+   **Explanation:** They are “co‑authors of two books on building better businesses” and help people “solve their work problems.”
+
+4. **What phrase do they use instead of “move fast and break things”?**  
+   A. Move slow and break things  
+   B. Move fast and fix things  
+   C. Move fast and ignore things  
+   D. Move slow and fix things  
+   **Answer:** B  
+   **Explanation:** The transcript says, “we say move fast and fix things.”
+
+5. **What is the name of the show they host?**  
+   A. Fixable  
+   B. Unfixible  
+   C. Fast Fix  
+   D. Break Things  
+   **Answer:** B  
+   **Explanation:** The transcript says, “Unfixible. This is a new show from the TED Audio Collective.”
+
+6. **What is the phone number to contact them?**  
+   A. 234‑349‑2253  
+   B. 123‑456‑7890  
+   C. 555‑555‑5555  
+   D. 111‑222‑3333  
+   **Answer:** A  
+   **Explanation:** The transcript gives the number “234‑349‑2253.”
+
+7. **What email domain do they use?**  
+   A. gmail.com  
+   B. yahoo.com  
+   C. TED.com  
+   D. hotmail.com  
+   **Answer:** C  
+   **Explanation:** The email is “fixable at TED.com.”
+
+8. **What do they want people to do on their podcast app?**  
+   A. Subscribe to Fixable  
+   B. Go to the gym  
+   C. Watch movies  
+   D. Read books  
+   **Answer:** A  
+   **Explanation:** The transcript says, “make sure to subscribe to Fixable right now on your favorite podcast app.”
+
+---
+
+### Fill in the Blank (6)
+
+1. They say “move fast and ____ things.”  
+   **Answer:** fix  
+   **Explanation:** The phrase is “move fast and fix things.”
+
+2. They help people from entrepreneurs to ____ of global corporations.  
+   **Answer:** CEOs  
+   **Explanation:** The transcript mentions “CEOs of global corporations.”
+
+3. They believe that everything is _____.  
+   **Answer:** fixable  
+   **Explanation:** The transcript repeats, “everything is fixable.”
+
+4. The show takes a call from someone who is _____.  
+   **Answer:** stuck  
+   **Explanation:** The transcript says, “take a call from someone who’s stuck.”
+
+5. The phone number starts with ____‑349‑2253.  
+   **Answer:** 234  
+   **Explanation:** The number is “234‑349‑2253.”
+
+6. The email is ____ at TED.com.  
+   **Answer:** fixable  
+   **Explanation:** The email address is “fixable at TED.com.”
+
+---
+
+### Short Answer (6)
+
+1. **What is Ann Morris’s profession?**  
+   **Answer:** She is a company builder and a leadership coach.  
+   **Explanation:** The transcript states, “My name is Ann Morris. I'm a company builder and a leadership coach.”
+
+2. **What is Frances Fry’s role?**  
+   **Answer:** She is an author and a Harvard Business School professor.  
+   **Explanation:** The transcript says, “I'm Frances Fry. I'm an author and a Harvard Business School professor.”
+
+3. **What is the main idea of their philosophy?**  
+   **Answer:** Move fast and fix things.  
+   **Explanation:** They explain, “we say move fast and fix things because in our experience, speed and fixing go hand in hand.”
+
+4. **What type of problems do they solve?**  
+   **Answer:** Work problems.  
+   **Explanation:** The transcript mentions, “We help them all solve their work problems.”
+
+5. **What is the purpose of the show?**  
+   **Answer:** To help people solve work problems by having a conversation.  
+   **Explanation:** The transcript says, “Each week, we’ll take a call from someone who’s stuck… we’ll guide people past those barriers so that they can make things happen.”
+
+6. **How can someone contact them?**  
+   **Answer:** By emailing fixable@TED.com or calling 234‑349‑2253.  
+   **Explanation:** The transcript gives both contact methods: “Email us at fixable at TED.com or give us a call at 234‑349‑2253.”
+
+---
+
+## Intermediate
+### Multiple Choice (8)
+
+1. What phrase do Ann and Frances say they use instead of “move fast and break things”?  
+   A. move fast and fix things  
+   B. move slow and fix things  
+   C. move fast and break things  
+   D. move slow and break things  
+   **Answer:** A  
+   **Explanation:** The transcript says, “we say move fast and fix things.”
+
+2. Who is Frances Fry?  
+   A. a company builder  
+   B. a leadership coach  
+   C. an author and Harvard Business School professor  
+   D. Ann’s wife  
+   **Answer:** C  
+   **Explanation:** The transcript introduces Frances as “an author and a Harvard Business School professor.”
+
+3. What is the name of the show they host?  
+   A. Fixable  
+   B. Unfixible  
+   C. Fix It  
+   D. The Fix  
+   **Answer:** B  
+   **Explanation:** The transcript states, “This is a new show from the TED Audio Collective. Each week, we’ll take a call… Unfixible.”
+
+4. Which of the following topics is NOT mentioned as part of the show?  
+   A. When to say enough is enough  
+   B. How to find your strengths  
+   C. How to build a startup  
+   D. What to do when your boss acts unethically  
+   **Answer:** C  
+   **Explanation:** The listed topics do not include building a startup.
+
+5. What is the phone number to contact them?  
+   A. 234‑349‑2253  
+   B. 234‑349‑2254  
+   C. 234‑349‑2252  
+   D. 234‑349‑2251  
+   **Answer:** A  
+   **Explanation:** The transcript gives the number as “234‑349‑2253.”
+
+6. Which statement best describes their belief about change?  
+   A. Change takes time  
+   B. Change is impossible  
+   C. Change happens fast and everything is fixable  
+   D. Change is only for CEOs  
+   **Answer:** C  
+   **Explanation:** They say, “meaningful change happens fast and everything is fixable.”
+
+7. What is the email address to contact them?  
+   A. fixable@TED.com  
+   B. fixable@TED.org  
+   C. fixable@TED.net  
+   D. fixable@TED.co  
+   **Answer:** A  
+   **Explanation:** The transcript lists the email as “fixable at TED.com.”
+
+8. What phrase do they use to describe the spirit they bring into organizations?  
+   A. Kandu Lesbian spirit  
+   B. Corporate spirit  
+   C. Entrepreneurial spirit  
+   D. Leadership spirit  
+   **Answer:** A  
+   **Explanation:** The transcript says, “Part of what we do… is bring some Kandu Lesbian spirit into organizations.”
+
+### Fill in the Blank (6)
+
+1. The authors say that speed signals you take a problem ___ seriously.  
+   **Answer:** seriously  
+   **Explanation:** The transcript says, “speed signals that you take a problem seriously.”
+
+2. They say that one good conversation can be ___ away from removing a roadblock.  
+   **Answer:** one  
+   **Explanation:** The transcript states, “often they're just one good conversation away.”
+
+3. They hope to spread the message that meaningful change happens ___ fast.  
+   **Answer:** fast  
+   **Explanation:** The transcript says, “meaningful change happens fast.”
+
+4. The show is called ___ .  
+   **Answer:** Unfixible  
+   **Explanation:** The transcript introduces the show as “Unfixible.”
+
+5. The phone number is ___ .  
+   **Answer:** 234‑349‑2253  
+   **Explanation:** The transcript gives the phone number as “234‑349‑2253.”
+
+6. They say that everything is ___ .  
+   **Answer:** fixable  
+   **Explanation:** The transcript repeats, “everything is fixable.”
+
+### Short Answer (6)
+
+1. **Question:** Who are the co‑authors of the two books mentioned?  
+   **Answer:** Ann Morris and Frances Fry  
+   **Explanation:** The transcript identifies them as the co‑authors.
+
+2. **Question:** What is the main goal of their conversations with clients?  
+   **Answer:** To remove roadblocks and find solutions.  
+   **Explanation:** They say, “often they're just one good conversation away from removing the roadblock and finding a solution.”
+
+3. **Question:** What type of problems do they help solve?  
+   **Answer:** Work problems for entrepreneurs and CEOs.  
+   **Explanation:** The transcript says they help “everyone from entrepreneurs just starting out to CEOs of global corporations.”
+
+4. **Question:** What is the main message they want to spread?  
+   **Answer:** That meaningful change happens fast and everything is fixable.  
+   **Explanation:** They state, “meaningful change happens fast and everything is fixable.”
+
+5. **Question:** How can someone contact them?  
+   **Answer:** By emailing fixable@TED.com or calling 234‑349‑2253.  
+   **Explanation:** The transcript provides both contact methods.
+
+6. **Question:** What unique spirit do they claim to bring into organizations?  
+   **Answer:** The Kandu Lesbian spirit.  
+   **Explanation:** The transcript

--- a/generated_questions_md/speed_and_scale_trailer_questions.md
+++ b/generated_questions_md/speed_and_scale_trailer_questions.md
@@ -1,0 +1,243 @@
+# Question Set: speed_and_scale_trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. **Who are the hosts of the podcast?**  
+   A. Angelie Grover only  
+   B. Ryan Pinchadsr only  
+   C. Angelie Grover and Ryan Pinchadsr  
+   D. No hosts are mentioned  
+   **Answer:** C  
+   **Explanation:** The transcript says, “I’m Angelie Grover, and I’m Ryan Pinchadsr.”
+
+2. **What was the main problem 10 years ago?**  
+   A. A desert turning into forest  
+   B. A tropical rainforest being replaced by plantations  
+   C. A city flooding  
+   D. A mountain range eroding  
+   **Answer:** B  
+   **Explanation:** The transcript describes the rainforest being gone and replaced by palm oil, pulp, and paper plantations.
+
+3. **What are the two cheapest ways to produce electricity?**  
+   A. Coal and gas  
+   B. Nuclear and hydro  
+   C. Wind and solar  
+   D. Oil and biomass  
+   **Answer:** C  
+   **Explanation:** The transcript states, “Wind and solar now are the two cheapest ways to produce electricity.”
+
+4. **In which year did the huge heat wave in Europe happen?**  
+   A. 2000  
+   B. 2004  
+   C. 2010  
+   D. 2015  
+   **Answer:** B  
+   **Explanation:** The transcript mentions a heat wave in 2004.
+
+5. **What is the target reduction for beef feedlot animals?**  
+   A. 80%  
+   B. 90%  
+   C. 98‑99%  
+   D. 100%  
+   **Answer:** C  
+   **Explanation:** The transcript says “over 98, 99% reductions in beef feedlot animals.”
+
+6. **Where is the podcast produced?**  
+   A. New York  
+   B. Tet  
+   C. London  
+   D. Tokyo  
+   **Answer:** B  
+   **Explanation:** The transcript says, “we’re bringing you a new podcast from Tet.”
+
+7. **How many tons of greenhouse gases are produced today?**  
+   A. 50 billion tons  
+   B. 59 billion tons  
+   C. 70 billion tons  
+   D. 80 billion tons  
+   **Answer:** B  
+   **Explanation:** The transcript states, “the 59 billion tons of greenhouse gases that are being produced today.”
+
+8. **When does the podcast start?**  
+   A. September 22nd  
+   B. October 1st  
+   C. August 15th  
+   D. July 4th  
+   **Answer:** A  
+   **Explanation:** The transcript says, “Starting on September 22nd, join us…”
+
+---
+
+### Fill in the Blank (6)
+
+1. In 2004, there was a huge heat wave in **Europe**.  
+   **Answer:** Europe  
+   **Explanation:** The transcript mentions the heat wave occurred in Europe.
+
+2. The hosts are Angelie Grover and **Ryan Pinchadsr**.  
+   **Answer:** Ryan Pinchadsr  
+   **Explanation:** The transcript introduces both hosts.
+
+3. Wind and solar are the two cheapest ways to produce **electricity**.  
+   **Answer:** electricity  
+   **Explanation:** The transcript says they are the cheapest ways to produce electricity.
+
+4. The podcast is from **Tet**.  
+   **Answer:** Tet  
+   **Explanation:** The transcript says, “a new podcast from Tet.”
+
+5. The meat industry can reduce dairy by up to **80%**.  
+   **Answer:** 80%  
+   **Explanation:** The transcript states “up to 80% reductions in dairy.”
+
+6. The podcast starts on **September 22nd**.  
+   **Answer:** September 22nd  
+   **Explanation:** The transcript gives this start date.
+
+---
+
+### Short Answer (6)
+
+1. **What is the main climate problem discussed?**  
+   **Answer:** Carbon pollution.  
+   **Explanation:** The transcript says, “this season, we're looking at one of the biggest challenges we're facing, carbon pollution.”
+
+2. **What is the main solution for the power grid?**  
+   **Answer:** Wind and solar power.  
+   **Explanation:** The transcript highlights wind and solar as the cheapest ways to produce electricity.
+
+3. **How many tons of greenhouse gases are produced today?**  
+   **Answer:** 59 billion tons.  
+   **Explanation:** The transcript mentions “the 59 billion tons of greenhouse gases that are being produced today.”
+
+4. **What is the reduction percentage for beef feedlot animals?**  
+   **Answer:** Over 98‑99%.  
+   **Explanation:** The transcript states “over 98, 99% reductions in beef feedlot animals.”
+
+5. **Who are the hosts?**  
+   **Answer:** Angelie Grover and Ryan Pinchadsr.  
+   **Explanation:** The transcript introduces both names.
+
+6. **When will the podcast episodes begin?**  
+   **Answer:** September 22nd.  
+   **Explanation:** The transcript says, “Starting on September 22nd, join us for these inspiring stories.”
+
+---
+
+## Intermediate
+### Multiple Choice (8)
+1. What type of plantations were most common in the tropical rainforest 10 years ago?  
+   A. Bamboo and eucalyptus plantations  
+   B. Palm oil and pulp & paper plantations  
+   C. Rubber and teak plantations  
+   D. Coconut and banana plantations  
+   **Answer:** B  
+   **Explanation:** The transcript says the rainforest was replaced by palm oil and pulp & paper plantations.
+
+2. Who are the hosts of the new podcast from Tet?  
+   A. Angelie Grover and Ryan Pinchadsr  
+   B. Angelie Grover and John Smith  
+   C. Ryan Pinchadsr and Maria Lopez  
+   D. John Smith and Maria Lopez  
+   **Answer:** A  
+   **Explanation:** The transcript introduces the hosts as Angelie Grover and Ryan Pinchadsr.
+
+3. According to the hosts, what has changed in the perception of climate solutions over the last five years?  
+   A. They are now considered impossible.  
+   B. They are now seen as too expensive.  
+   C. They are now seen as within reach.  
+   D. They are now seen as unnecessary.  
+   **Answer:** C  
+   **Explanation:** The transcript states that five years ago it felt daunting, but now the problem feels within reach.
+
+4. Which event in 2004 is mentioned as a turning point for climate awareness?  
+   A. A massive forest fire in Australia  
+   B. A heat wave in Europe that killed thousands  
+   C. A hurricane in the Caribbean  
+   D. A drought in Africa  
+   **Answer:** B  
+   **Explanation:** The transcript refers to a 2004 heat wave in Europe where thousands died.
+
+5. What is the target amount of greenhouse gases the podcast claims to address?  
+   A. 59 million tons  
+   B. 59 billion tons  
+   C. 590 million tons  
+   D. 590 billion tons  
+   **Answer:** B  
+   **Explanation:** The transcript mentions “59 billion tons of greenhouse gases.”
+
+6. Which two energy sources are described as the cheapest ways to produce electricity?  
+   A. Coal and natural gas  
+   B. Nuclear and hydroelectric  
+   C. Wind and solar  
+   D. Biomass and geothermal  
+   **Answer:** C  
+   **Explanation:** The transcript states wind and solar are the two cheapest ways.
+
+7. What percentage reduction in dairy production is mentioned?  
+   A. 50%  
+   B. 60%  
+   C. 70%  
+   D. 80%  
+   **Answer:** D  
+   **Explanation:** The transcript says “as high as 80% reductions in dairy.”
+
+8. When does the podcast series start airing?  
+   A. August 15th  
+   B. September 22nd  
+   C. October 1st  
+   D. November 5th  
+   **Answer:** B  
+   **Explanation:** The transcript says “Starting on September 22nd.”
+
+### Fill in the Blank (6)
+1. The hosts of the podcast are Angelie Grover and _____.  
+   **Answer:** Ryan Pinchadsr  
+   **Explanation:** The transcript names both hosts.
+
+2. The podcast focuses on the challenge of _____.  
+   **Answer:** carbon pollution  
+   **Explanation:** The transcript states the season looks at one of the biggest challenges: carbon pollution.
+
+3. Wind and solar became the cheapest ways to produce electricity in the last ____ years.  
+   **Answer:** 25  
+   **Explanation:** The transcript says “happened in what, 25 years.”
+
+4. The podcast claims to stop literal gigatons of carbon emissions in their _____.  
+   **Answer:** tracks  
+   **Explanation:** The transcript says “stopping literal gigatons of carbon emissions in their tracks.”
+
+5. The podcast aims to achieve over ____% reductions in beef feedlot animals.  
+   **Answer:** 98-99  
+   **Explanation:** The transcript says “over 98, 99% reductions in beef feedlot animals.”
+
+6. The hosts say we need to supercharge solutions with speed and _____.  
+   **Answer:** scale  
+   **Explanation:** The transcript ends with “speed and scale.”
+
+### Short Answer (6)
+1. What was the main environmental problem described 10 years ago?  
+   **Answer:** The destruction of tropical rainforest, replaced by palm oil and pulp & paper plantations.  
+   **Explanation:** The transcript describes the rainforest being replaced by plantations and nature suffering.
+
+2. Who is the other host besides Angelie Grover?  
+   **Answer:** Ryan Pinchadsr  
+   **Explanation:** The transcript names both hosts.
+
+3. In what year did the heat wave in Europe occur?  
+   **Answer:** 2004  
+   **Explanation:** The transcript mentions a 2004 heat wave.
+
+4. What is the estimated amount of greenhouse gases produced today that the podcast targets?  
+   **Answer:** 59 billion tons  
+   **Explanation:** The transcript states “59 billion tons of greenhouse gases.”
+
+5. Which two industries are highlighted for potential emissions reductions?  
+   **Answer:** The power grid (wind & solar) and the meat industry (dairy and beef).  
+   **Explanation:** The transcript discusses power grid, wind & solar, and meat industry reductions.
+
+6. What date does the podcast series begin?  
+   **Answer:** September 22nd  
+   **Explanation:** The transcript says “Starting on September 22nd.”

--- a/generated_questions_md/ted_ai_trailer_questions.md
+++ b/generated_questions_md/ted_ai_trailer_questions.md
@@ -1,0 +1,251 @@
+# Question Set: ted_ai_trailer.txt
+
+## Beginner
+
+### Multiple Choice (8)
+
+1. Who is speaking in the transcript?  
+   A. A scientist  
+   B. A visual effects artist  
+   C. A politician  
+   D. A musician  
+   **Answer:** B  
+   **Explanation:** The speaker says, “I’m a visual effects artist…”
+
+2. What is the speaker’s job?  
+   A. Teacher  
+   B. Visual effects artist  
+   C. Chef  
+   D. Lawyer  
+   **Answer:** B  
+   **Explanation:** The speaker identifies himself as a visual effects artist.
+
+3. What show does the speaker host?  
+   A. TED Music Show  
+   B. TED AI Show  
+   C. TED Sports Show  
+   D. TED Cooking Show  
+   **Answer:** B  
+   **Explanation:** He says, “I’m the host of an exciting new TED podcast, The TED AI Show.”
+
+4. Who is the show aimed at?  
+   A. People who love cooking  
+   B. People afraid of robots  
+   C. People who like sports  
+   D. People who like gardening  
+   **Answer:** B  
+   **Explanation:** He mentions, “If you’re afraid of losing your job to a robot… we made the show for you.”
+
+5. Where did the speaker build ARVR products?  
+   A. Apple  
+   B. Microsoft  
+   C. Google  
+   D. Amazon  
+   **Answer:** C  
+   **Explanation:** He says, “I’m taking everything I know from my work building ARVR products at Google…”
+
+6. How does the speaker feel about new technology?  
+   A. It’s scary  
+   B. It’s exciting  
+   C. It’s boring  
+   D. It’s useless  
+   **Answer:** B  
+   **Explanation:** He says, “I actually believe that there’s a lot to be excited about.”
+
+7. Who will the speaker talk to on the show?  
+   A. Chefs  
+   B. Researchers  
+   C. Politicians  
+   D. Musicians  
+   **Answer:** B  
+   **Explanation:** He says, “I’ll be talking to our researchers, artists, journalists…”
+
+8. What is the speaker’s attitude toward AI?  
+   A. Fearful  
+   B. Optimistic  
+   C. Indifferent  
+   D. Angry  
+   **Answer:** B  
+   **Explanation:** He describes himself as a “cautiously optimistic AI enthusiast.”
+
+---
+
+### Fill in the Blank (6)
+
+1. He is a visual effects artist, a spatial computing expert, and a cautiously optimistic AI ____.  
+   **Answer:** enthusiast  
+   **Explanation:** The transcript uses the word “enthusiast” after “AI.”
+
+2. He is the host of an exciting new TED podcast, The TED ____.  
+   **Answer:** AI  
+   **Explanation:** The show’s name is “The TED AI Show.”
+
+3. If you’re afraid of losing your job to a robot or struggling to keep up with the latest ____, we made the show for you.  
+   **Answer:** tech  
+   **Explanation:** The speaker says, “latest tech.”
+
+4. He is taking everything he knows from building ARVR products at ____.  
+   **Answer:** Google  
+   **Explanation:** He mentions “building ARVR products at Google.”
+
+5. He will talk to researchers, artists, journalists, and people whose jobs haven’t even been invented yet to make sense of ____.  
+   **Answer:** it all  
+   **Explanation:** The phrase “make sense of it all” appears in the transcript.
+
+6. He says adapting to new technology is ____, but he believes there’s a lot to be excited about.  
+   **Answer:** stressful  
+   **Explanation:** The speaker says, “Adapting to new technology is stressful.”
+
+---
+
+### Short Answer (6)
+
+1. **Question:** What is the host’s name?  
+   **Answer:** Belovels Hadoop  
+   **Explanation:** The transcript starts with “Hey, I’m Belovels Hadoop.”
+
+2. **Question:** What type of products does he build?  
+   **Answer:** ARVR products  
+   **Explanation:** He says, “my work building ARVR products at Google.”
+
+3. **Question:** What is the main topic of the podcast?  
+   **Answer:** AI  
+   **Explanation:** The podcast is called “The TED AI Show.”
+
+4. **Question:** Who is the target audience?  
+   **Answer:** People who are afraid of robots or struggling to keep up with tech  
+   **Explanation:** He says, “If you’re afraid of losing your job to a robot or struggling to keep up with the latest tech, we made the show for you.”
+
+5. **Question:** Where can listeners subscribe?  
+   **Answer:** Wherever they get their podcasts  
+   **Explanation:** He says, “Subscribe to The TED AI Show wherever you get your podcasts.”
+
+6. **Question:** What does he want listeners to do?  
+   **Answer:** Subscribe to The TED AI Show  
+   **Explanation:** He ends with a call to action: “Subscribe to The TED AI Show.”
+
+---
+
+## Intermediate
+
+### Multiple Choice (8)
+
+1. **What is Belovels Hadoop’s main profession?**  
+   A. Visual effects artist  
+   B. Software engineer  
+   C. Journalist  
+   D. Musician  
+   **Answer:** A  
+   **Explanation:** The transcript says, “I’m a visual effects artist…”
+
+2. **Which field is he an expert in?**  
+   A. Spatial computing  
+   B. Astrophysics  
+   C. Culinary arts  
+   D. Marine biology  
+   **Answer:** A  
+   **Explanation:** He describes himself as “a spatial computing expert.”
+
+3. **What is the name of the podcast he hosts?**  
+   A. TED AI Show  
+   B. AI Podcast  
+   C. TED Talk  
+   D. The Future Show  
+   **Answer:** A  
+   **Explanation:** He says, “I’m the host of an exciting new TED podcast, The TED AI Show.”
+
+4. **Who is the podcast aimed at?**  
+   A. People afraid of robots or struggling with tech  
+   B. People who love cooking  
+   C. Sports fans  
+   D. Travelers  
+   **Answer:** A  
+   **Explanation:** He says, “If you’re afraid of losing your job to a robot or struggling to keep up with the latest tech, we made the show for you.”
+
+5. **Where did he build ARVR products?**  
+   A. Google  
+   B. Apple  
+   C. Amazon  
+   D. Microsoft  
+   **Answer:** A  
+   **Explanation:** He mentions, “my work building ARVR products at Google.”
+
+6. **What type of videos does he enjoy making?**  
+   A. Reality‑bending videos  
+   B. Cooking videos  
+   C. Travel videos  
+   D. Documentary videos  
+   **Answer:** A  
+   **Explanation:** He says, “to my passion for making reality‑bending videos.”
+
+7. **How does he describe adapting to new technology?**  
+   A. Stressful  
+   B. Easy  
+   C. Irrelevant  
+   D. Impossible  
+   **Answer:** A  
+   **Explanation:** He states, “Adapting to new technology is stressful…”
+
+8. **What is his final message about AI?**  
+   A. Navigate AI before it navigates us  
+   B. Ignore AI  
+   C. Wait for AI  
+   D. Trust AI  
+   **Answer:** A  
+   **Explanation:** He ends with, “So let’s figure out together how to navigate AI before it navigates us.”
+
+---
+
+### Fill in the Blank (6)
+
+1. He is a **cautiously optimistic AI** enthusiast.  
+   **Answer:** cautiously optimistic AI  
+   **Explanation:** The transcript says, “a cautiously optimistic AI enthusiast.”
+
+2. He hosts the podcast called **The TED AI Show**.  
+   **Answer:** The TED AI Show  
+   **Explanation:** He introduces the podcast by name.
+
+3. He works building ARVR products at **Google**.  
+   **Answer:** Google  
+   **Explanation:** He mentions his work at Google.
+
+4. He talks to researchers, artists, journalists, and people whose jobs haven’t even been invented yet to **make sense of** it all.  
+   **Answer:** make sense of  
+   **Explanation:** The transcript says, “to make sense of it all.”
+
+5. Adapting to new technology is **stressful**.  
+   **Answer:** stressful  
+   **Explanation:** He explicitly calls it stressful.
+
+6. He believes there is a lot to be **excited about**.  
+   **Answer:** excited about  
+   **Explanation:** He says, “there’s a lot to be excited about.”
+
+---
+
+### Short Answer (6)
+
+1. **What does Belovels Hadoop do?**  
+   **Answer:** He is a visual effects artist and spatial computing expert.  
+   **Explanation:** The transcript lists both roles.
+
+2. **What is the main theme of the podcast?**  
+   **Answer:** AI and its impact on jobs and society.  
+   **Explanation:** He talks about AI, robots, and keeping up with tech.
+
+3. **Why did he create the podcast?**  
+   **Answer:** To help people who fear losing jobs to robots and keep up with technology.  
+   **Explanation:** He says the show is for those afraid of losing jobs or struggling to keep up.
+
+4. **Where does he get his experience from?**  
+   **Answer:** Building ARVR products at Google.  
+   **Explanation:** He cites his work at Google as the source of knowledge.
+
+5. **Who will he interview on the show?**  
+   **Answer:** Researchers, artists, journalists, and future job creators.  
+   **Explanation:** He lists these groups in the transcript.
+
+6. **What is his attitude toward new technology?**  
+   **Answer:** Cautiously optimistic and excited.  
+   **Explanation:** He describes himself as “cautiously optimistic” and says there’s a lot to be excited about.


### PR DESCRIPTION
**Changes**

· Restructure the Listening Lab from a single all-in-one page into a level entry page plus dedicated level practice pages
· Add new Beginner and Intermediate listening flows for Lecture Clips only, while keeping Group Discussion, Q&A Session, Office Hour, and Advanced visible in the UI as coming-soon content
· Load the 10 existing lecture materials dynamically from Audio, output, and generated_questions_md without changing the current database schema
· Use only multiple-choice questions for Beginner, and only fill-in-the-blank plus short-answer questions for Intermediate
· Add backend quiz parsing and submission/grading endpoints to return score, correctness, explanations, and transcript after submission
· Preserve the existing project structure and UI style while extending the current listening module without affecting other features
· Add backend and frontend tests to cover the new listening practice flow

**Files Changed**

· [backend/app/routes/listening.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Added listening practice data loading, markdown question parsing, quiz fetch/submit endpoints, and grading logic
· [backend/tests/test_listening.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Updated listening API coverage for the new catalog structure and quiz submission flow
· [frontend/src/pages/Listening.jsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Rebuilt the Listening page into entry/detail practice views with quiz answering, results, explanations, and transcript display
· [frontend/src/pages/Listening.test.jsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Added tests for landing navigation, Beginner quiz flow, and Intermediate quiz flow
· [frontend/src/api/index.js](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Added frontend API methods for fetching and submitting listening practice
· [frontend/src/App.jsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Added level-specific listening route support
· [frontend/src/components/NavBar.jsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/lenovo/.vscode/extensions/openai.chatgpt-26.5313.41514-win32-x64/webview/) - Kept the Listening navigation state correct on nested listening routes

**How to Test**

Start the backend and frontend locally, then log in and open /listening
Click Beginner, enter Lecture Clips, choose one of the 10 clips, answer the multiple-choice questions, and submit
Verify that the page refreshes into the result state showing score, correct/incorrect feedback, explanations, and transcript
Repeat the flow in Intermediate and verify that only fill-in-the-blank and short-answer questions are shown
Run:
python -m pytest backend\tests\test_listening.py -q
Run:
python -m pytest backend\tests\test_auth.py -q
Run:
npm test -- Listening
Run:
npm test -- AudioPlayer

**Note for teammates**

· No database migration is required for this change
· Listening practice content is read directly from Audio, output, and generated_questions_md
· Only Beginner and Intermediate Lecture Clips are enabled in this phase; the other listening scenarios remain in the UI for future development