### PR TITLE
refine word model, profile and learning progress recording + unit test

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -43,16 +43,30 @@ def create_app(config_name=None):
     from app.routes.word_bank import word_bank_bp
     from app.routes.daily_learning import daily_learning_bp
     from app.routes.listening import listening_bp
+    from app.routes.progress import progress_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(daily_words_bp)
     app.register_blueprint(word_bank_bp)
     app.register_blueprint(daily_learning_bp)
     app.register_blueprint(listening_bp)
+    app.register_blueprint(progress_bp)
 
     # Create database tables and auto-seed on first run
     with app.app_context():
-        from app.models import user, word, word_bank, review_history, user_word_progress  # noqa: F401
+        from app.models import (  # noqa: F401
+            chat_message,
+            chat_session,
+            listening_attempt,
+            listening_clip,
+            progress,
+            review_history,
+            speaking_session,
+            user,
+            user_word_progress,
+            word,
+            word_bank,
+        )
         db.create_all()
         _seed_words_if_empty(app)
         if app.config.get('DEBUG'):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.user import User
 from app.models.word import Word
 from app.models.word_bank import WordBank
 from app.models.listening_clip import ListeningClip
+from app.models.listening_attempt import ListeningAttempt
 from app.models.speaking_session import SpeakingSession
 from app.models.chat_session import ChatSession
 from app.models.chat_message import ChatMessage
@@ -27,6 +28,7 @@ __all__ = [
     'Word',
     'WordBank',
     'ListeningClip',
+    'ListeningAttempt',
     'SpeakingSession',
     'ChatSession',
     'ChatMessage',

--- a/backend/app/models/listening_attempt.py
+++ b/backend/app/models/listening_attempt.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+
+from app import db
+
+
+class ListeningAttempt(db.Model):
+    __tablename__ = 'listening_attempts'
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'user_id',
+            'level_id',
+            'scenario_id',
+            'source_slug',
+            name='uq_listening_attempt_user_activity',
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+    level_id = db.Column(db.String(20), nullable=False)
+    scenario_id = db.Column(db.String(50), nullable=False)
+    source_slug = db.Column(db.String(200), nullable=False)
+    answers_json = db.Column(db.Text, nullable=False)
+    results_json = db.Column(db.Text, nullable=False)
+    transcript = db.Column(db.Text, nullable=False)
+    score = db.Column(db.Float, nullable=False)
+    correct_count = db.Column(db.Integer, nullable=False)
+    total_count = db.Column(db.Integer, nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=db.text('CURRENT_TIMESTAMP'),
+    )
+
+    user = db.relationship('User', backref='listening_attempts')
+
+    def to_dict(self):
+        import json
+
+        return {
+            'id': self.id,
+            'level_id': self.level_id,
+            'scenario_id': self.scenario_id,
+            'source_slug': self.source_slug,
+            'answers': json.loads(self.answers_json),
+            'results': json.loads(self.results_json),
+            'transcript': self.transcript,
+            'score': self.score,
+            'correct_count': self.correct_count,
+            'total_count': self.total_count,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routes/daily_learning.py
+++ b/backend/app/routes/daily_learning.py
@@ -38,9 +38,18 @@ def get_today_words():
         UserWordProgress.assigned_date == today
     ).count()
 
+    # Carry-over words already studied today should still count toward today's cap,
+    # otherwise finishing old pending words would immediately unlock a fresh batch.
+    processed_carryover_today_count = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.assigned_date < today,
+        UserWordProgress.status != 'pending',
+        db.func.date(UserWordProgress.updated_at) == today
+    ).count()
+
     # How many new words should be assigned today
-    today_target = max(0, daily_count - carryover_count)
-    new_needed = max(0, today_target - assigned_today_count)
+    daily_slots_used = carryover_count + assigned_today_count + processed_carryover_today_count
+    new_needed = max(0, daily_count - daily_slots_used)
 
     if new_needed > 0:
         # Get word IDs already in progress for this user
@@ -66,11 +75,29 @@ def get_today_words():
 
         db.session.commit()
 
-    # Return all currently pending words (carry-over + today's remaining)
-    pending = UserWordProgress.query.filter_by(
-        user_id=current_user.id,
-        status='pending'
-    ).all()
+    completed_today_count = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.assigned_date == today,
+        UserWordProgress.status != 'pending',
+    ).count()
+
+    carryover_pending = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.status == 'pending',
+        UserWordProgress.assigned_date < today,
+    ).order_by(UserWordProgress.assigned_date.asc(), UserWordProgress.id.asc()).all()
+
+    today_pending = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.status == 'pending',
+        UserWordProgress.assigned_date == today,
+    ).order_by(UserWordProgress.id.asc()).all()
+
+    remaining_today_slots = max(
+        0,
+        daily_count - len(carryover_pending) - processed_carryover_today_count - completed_today_count
+    )
+    pending = carryover_pending + today_pending[:remaining_today_slots]
 
     review_count = UserWordProgress.query.filter_by(
         user_id=current_user.id,
@@ -160,12 +187,7 @@ def get_all_words():
 
     query = Word.query
     if search:
-        query = query.filter(
-            db.or_(
-                Word.text.ilike(f'%{search}%'),
-                Word.definition.ilike(f'%{search}%')
-            )
-        )
+        query = query.filter(Word.text.ilike(f'%{search}%'))
 
     total = query.count()
     words = query.order_by(Word.id).offset((page - 1) * per_page).limit(per_page).all()

--- a/backend/app/routes/listening.py
+++ b/backend/app/routes/listening.py
@@ -1,9 +1,14 @@
 import re
 import unicodedata
+import json
 from pathlib import Path
 
 from flask import Blueprint, jsonify, request, send_from_directory
-from flask_login import login_required
+from flask_login import current_user, login_required
+
+from app import db
+from app.models.listening_attempt import ListeningAttempt
+from app.models.progress import Progress
 
 listening_bp = Blueprint('listening', __name__, url_prefix='/api/listening')
 
@@ -534,6 +539,15 @@ def _build_practice_payload(level, scenario, source, include_answers=False):
     return payload
 
 
+def _find_saved_attempt(user_id, level_id, scenario_id, source_slug):
+    return ListeningAttempt.query.filter_by(
+        user_id=user_id,
+        level_id=level_id,
+        scenario_id=scenario_id,
+        source_slug=source_slug,
+    ).first()
+
+
 def _find_level(level_id):
     return next((level for level in LEVELS if level['id'] == level_id), None)
 
@@ -675,6 +689,9 @@ def get_listening_practice(level_id, scenario_id, source_slug):
     if payload is None:
         return jsonify({'error': 'Questions were not found for this clip'}), 404
 
+    saved_attempt = _find_saved_attempt(current_user.id, level_id, scenario_id, source_slug)
+    payload['saved_attempt'] = saved_attempt.to_dict() if saved_attempt else None
+
     return jsonify(payload), 200
 
 
@@ -704,6 +721,45 @@ def submit_listening_practice(level_id, scenario_id, source_slug):
     correct_count = sum(1 for result in results if result['is_correct'])
     total_count = len(results)
     score = round((correct_count / total_count) * 100, 1) if total_count else 0
+    time_spent = payload.get('time_spent')
+    time_spent = time_spent if isinstance(time_spent, int) and time_spent >= 0 else None
+
+    progress_record = Progress(
+        user_id=current_user.id,
+        module='listening',
+        activity_type=f'{level_id}:{scenario_id}:{source_slug}',
+        score=score,
+        time_spent=time_spent,
+    )
+    db.session.add(progress_record)
+
+    serialized_answers = {}
+    for question in questions:
+        serialized_answers[question['id']] = answers.get(question['id'], '')
+
+    saved_attempt = _find_saved_attempt(current_user.id, level_id, scenario_id, source_slug)
+    if saved_attempt is None:
+        saved_attempt = ListeningAttempt(
+            user_id=current_user.id,
+            level_id=level_id,
+            scenario_id=scenario_id,
+            source_slug=source_slug,
+            answers_json='{}',
+            results_json='[]',
+            transcript='',
+            score=0,
+            correct_count=0,
+            total_count=0,
+        )
+        db.session.add(saved_attempt)
+
+    saved_attempt.answers_json = json.dumps(serialized_answers)
+    saved_attempt.results_json = json.dumps(results)
+    saved_attempt.transcript = source['transcript']
+    saved_attempt.score = score
+    saved_attempt.correct_count = correct_count
+    saved_attempt.total_count = total_count
+    db.session.commit()
 
     return jsonify({
         'level': {
@@ -715,6 +771,7 @@ def submit_listening_practice(level_id, scenario_id, source_slug):
             'label': scenario['label'],
         },
         'clip': _clip_from_source(source, level, scenario),
+        'progress_id': progress_record.id,
         'score': score,
         'correct_count': correct_count,
         'total_count': total_count,

--- a/backend/app/routes/progress.py
+++ b/backend/app/routes/progress.py
@@ -1,0 +1,72 @@
+from flask import Blueprint, jsonify, request
+from flask_login import current_user, login_required
+
+from app import db
+from app.models.progress import Progress
+from app.models.speaking_session import SpeakingSession
+from app.models.user_word_progress import UserWordProgress
+
+progress_bp = Blueprint('progress', __name__, url_prefix='/api/progress')
+
+TIME_TRACKING_MODULES = {'vocab', 'listening', 'speaking', 'chat'}
+
+
+@progress_bp.route('/track-time', methods=['POST'])
+@login_required
+def track_progress_time():
+    payload = request.get_json(silent=True) or {}
+    module = payload.get('module')
+    activity_type = payload.get('activity_type')
+    time_spent = payload.get('time_spent')
+
+    if module not in TIME_TRACKING_MODULES:
+        return jsonify({'error': 'Unsupported module'}), 400
+
+    if not isinstance(activity_type, str) or not activity_type.strip():
+        return jsonify({'error': 'activity_type is required'}), 400
+
+    if not isinstance(time_spent, int) or time_spent <= 0:
+        return jsonify({'error': 'time_spent must be a positive integer'}), 400
+
+    progress_record = Progress(
+        user_id=current_user.id,
+        module=module,
+        activity_type=activity_type.strip(),
+        time_spent=time_spent,
+    )
+    db.session.add(progress_record)
+    db.session.commit()
+
+    return jsonify(progress_record.to_dict()), 201
+
+
+@progress_bp.route('/dashboard', methods=['GET'])
+@login_required
+def get_progress_dashboard():
+    words_learned = UserWordProgress.query.filter(
+        UserWordProgress.user_id == current_user.id,
+        UserWordProgress.status.in_(('review', 'mastered')),
+    ).count()
+
+    listening_done = db.session.query(
+        db.func.count(db.distinct(Progress.activity_type))
+    ).filter(
+        Progress.user_id == current_user.id,
+        Progress.module == 'listening',
+        ~Progress.activity_type.like('study_time:%')
+    ).scalar() or 0
+
+    speaking_sessions = SpeakingSession.query.filter_by(user_id=current_user.id).count()
+
+    total_time_minutes = db.session.query(
+        db.func.coalesce(db.func.sum(Progress.time_spent), 0)
+    ).filter(
+        Progress.user_id == current_user.id
+    ).scalar() or 0
+
+    return jsonify({
+        'words_learned': words_learned,
+        'listening_done': listening_done,
+        'speaking_sessions': speaking_sessions,
+        'total_time_minutes': int(total_time_minutes),
+    }), 200

--- a/backend/tests/test_daily_learning.py
+++ b/backend/tests/test_daily_learning.py
@@ -61,6 +61,79 @@ def test_get_today_includes_carryover_and_only_assigns_remaining_slots(
     }
 
 
+def test_get_today_does_not_refill_same_day_after_carryover_is_completed(
+    client,
+    login_user,
+    create_word,
+):
+    login_user()
+    old_word_one = create_word(text='carryover-1')
+    old_word_two = create_word(text='carryover-2')
+    create_word(text='new-1')
+    create_word(text='new-2')
+
+    yesterday = date.today() - timedelta(days=1)
+    first_progress = UserWordProgress(
+        user_id=1,
+        word_id=old_word_one.id,
+        status='pending',
+        assigned_date=yesterday,
+    )
+    second_progress = UserWordProgress(
+        user_id=1,
+        word_id=old_word_two.id,
+        status='pending',
+        assigned_date=yesterday,
+    )
+    db.session.add(first_progress)
+    db.session.add(second_progress)
+    db.session.commit()
+
+    first_response = client.get('/api/daily-learning/today?count=2')
+    assert first_response.status_code == 200
+    assert {word['text'] for word in first_response.get_json()['words']} == {
+        'carryover-1',
+        'carryover-2',
+    }
+
+    client.post('/api/daily-learning/word-status', json={'progress_id': first_progress.id, 'status': 'review'})
+    client.post('/api/daily-learning/word-status', json={'progress_id': second_progress.id, 'status': 'review'})
+
+    second_response = client.get('/api/daily-learning/today?count=2')
+    assert second_response.status_code == 200
+    assert second_response.get_json()['words'] == []
+
+
+def test_get_today_hides_excess_pending_words_when_daily_limit_is_reduced(
+    client,
+    login_user,
+    create_word,
+):
+    login_user()
+
+    created_words = [create_word(text=f'word-{index}') for index in range(20)]
+
+    first_response = client.get('/api/daily-learning/today?count=10')
+    assert first_response.status_code == 200
+    first_batch = first_response.get_json()['words']
+    assert len(first_batch) == 10
+
+    for progress in first_batch:
+        client.post('/api/daily-learning/word-status', json={'progress_id': progress['id'], 'status': 'review'})
+
+    second_response = client.get('/api/daily-learning/today?count=20')
+    assert second_response.status_code == 200
+    second_batch = second_response.get_json()['words']
+    assert len(second_batch) == 10
+    assert {word['word_id'] for word in second_batch} == {word.id for word in created_words[10:20]}
+
+    third_response = client.get('/api/daily-learning/today?count=10')
+    assert third_response.status_code == 200
+    third_data = third_response.get_json()
+    assert third_data['words'] == []
+    assert third_data['pending_count'] == 0
+
+
 def test_update_word_status_validates_input(client, login_user):
     login_user()
 
@@ -134,6 +207,18 @@ def test_get_all_words_includes_progress_and_bank_flags(client, login_user, crea
     assert data['words'][0]['text'] == 'empirical'
     assert data['words'][0]['progress_status'] is None
     assert data['words'][0]['in_word_bank'] is True
+
+
+def test_get_all_words_search_only_matches_word_text(client, login_user, create_word):
+    login_user()
+    create_word(text='abacus', definition='A counting frame.')
+    create_word(text='zebra', definition='Contains character c in definition.')
+
+    response = client.get('/api/daily-learning/all-words?search=c')
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert {word['text'] for word in data['words']} == {'abacus'}
 
 
 def test_get_learning_stats_returns_expected_counts(client, login_user, create_word):

--- a/backend/tests/test_listening.py
+++ b/backend/tests/test_listening.py
@@ -1,3 +1,6 @@
+from app.models.progress import Progress
+
+
 def test_listening_catalog_returns_levels_and_supported_lecture_clips(client, login_user):
     login_user()
 
@@ -125,3 +128,88 @@ def test_intermediate_practice_submission_returns_score_and_results(client, logi
     assert results_by_prompt['The podcast is hosted by ____.']['is_correct'] is True
     assert results_by_prompt['What is the main goal of the podcast?']['is_correct'] is True
     assert results_by_prompt['The show’s title is “How to Be a ____ Human.”']['is_correct'] is False
+    assert isinstance(result['progress_id'], int) is True
+
+    progress = Progress.query.get(result['progress_id'])
+    assert progress is not None
+    assert progress.user_id == 1
+    assert progress.module == 'listening'
+    assert progress.activity_type == 'intermediate:lecture-clips:better-human-trailer'
+    assert progress.score == result['score']
+
+
+def test_listening_practice_returns_saved_attempt_for_same_user(client, login_user):
+    login_user()
+
+    quiz_response = client.get('/api/listening/quiz/beginner/lecture-clips/better-human-trailer')
+    assert quiz_response.status_code == 200
+    quiz = quiz_response.get_json()
+
+    answers = {}
+    for question in quiz['questions']:
+        answers[question['id']] = 'A'
+
+    submit_response = client.post(
+        '/api/listening/quiz/beginner/lecture-clips/better-human-trailer/submit',
+        json={'answers': answers},
+    )
+    assert submit_response.status_code == 200
+
+    practice_response = client.get('/api/listening/quiz/beginner/lecture-clips/better-human-trailer')
+    assert practice_response.status_code == 200
+    practice_data = practice_response.get_json()
+
+    assert practice_data['saved_attempt'] is not None
+    assert practice_data['saved_attempt']['answers'] == answers
+    assert practice_data['saved_attempt']['results']
+
+
+def test_listening_audio_route_returns_404_for_unknown_clip(client, login_user):
+    login_user()
+
+    response = client.get('/api/listening/audio/not-a-real-clip')
+
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'Clip not found'
+
+
+def test_listening_practice_route_rejects_unsupported_scenario(client, login_user):
+    login_user()
+
+    response = client.get('/api/listening/quiz/beginner/group-discussion/better-human-trailer')
+
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'Practice for this level and scenario is coming soon'
+
+
+def test_listening_practice_route_returns_404_for_unknown_clip(client, login_user):
+    login_user()
+
+    response = client.get('/api/listening/quiz/beginner/lecture-clips/not-a-real-clip')
+
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'Practice material not found'
+
+
+def test_listening_submission_requires_answers_object(client, login_user):
+    login_user()
+
+    response = client.post(
+        '/api/listening/quiz/intermediate/lecture-clips/better-human-trailer/submit',
+        json={'answers': ['not', 'a', 'dict']},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Answers must be provided as an object'
+
+
+def test_listening_submission_rejects_unsupported_level_and_scenario(client, login_user):
+    login_user()
+
+    response = client.post(
+        '/api/listening/quiz/advanced/lecture-clips/better-human-trailer/submit',
+        json={'answers': {}},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'Practice for this level and scenario is coming soon'

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -1,0 +1,80 @@
+from app import db
+from app.models.progress import Progress
+from app.models.speaking_session import SpeakingSession
+from app.models.user_word_progress import UserWordProgress
+
+
+def test_track_progress_time_creates_study_time_record(client, login_user):
+    login_user()
+
+    response = client.post(
+        '/api/progress/track-time',
+        json={
+            'module': 'vocab',
+            'activity_type': 'study_time:daily-words',
+            'time_spent': 12,
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['module'] == 'vocab'
+    assert data['activity_type'] == 'study_time:daily-words'
+    assert data['time_spent'] == 12
+
+
+def test_progress_dashboard_returns_real_user_metrics(client, login_user, create_word):
+    login_user()
+
+    learned_word = create_word(text='analyze')
+    pending_word = create_word(text='compile')
+
+    db.session.add(UserWordProgress(user_id=1, word_id=learned_word.id, status='mastered'))
+    db.session.add(UserWordProgress(user_id=1, word_id=pending_word.id, status='pending'))
+    db.session.add(Progress(
+        user_id=1,
+        module='listening',
+        activity_type='beginner:lecture-clips:campus-welcome',
+        score=100,
+        time_spent=15,
+    ))
+    db.session.add(Progress(
+        user_id=1,
+        module='listening',
+        activity_type='beginner:lecture-clips:campus-welcome',
+        score=80,
+        time_spent=6,
+    ))
+    db.session.add(Progress(
+        user_id=1,
+        module='listening',
+        activity_type='intermediate:lecture-clips:research-methods',
+        score=90,
+        time_spent=9,
+    ))
+    db.session.add(Progress(
+        user_id=1,
+        module='listening',
+        activity_type='study_time:listening',
+        score=None,
+        time_spent=8,
+    ))
+    db.session.add(Progress(
+        user_id=1,
+        module='chat',
+        activity_type='study_time:ai-chat',
+        score=None,
+        time_spent=20,
+    ))
+    db.session.add(SpeakingSession(user_id=1, topic='orientation'))
+    db.session.commit()
+
+    response = client.get('/api/progress/dashboard')
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        'words_learned': 1,
+        'listening_done': 2,
+        'speaking_sessions': 1,
+        'total_time_minutes': 58,
+    }

--- a/docs/unit-test-sprint1.md
+++ b/docs/unit-test-sprint1.md
@@ -3,33 +3,36 @@
 ## 1. Document Information
 
 - Project: Academic English Practice App
-- Sprint: Sprint 1 - Vocabulary Module
-- Scope: Authentication, Daily Words, Word Bank
-- Verification date: 2026-03-18
-- Repository: `/Users/huruoqi/Desktop/BOT_0`
+- Sprint: Sprint 1 - Vocabulary and Listening Foundation
+- Scope: Authentication, Daily Words, Word Bank, Daily Learning, Listening, Progress Dashboard
+- Verification date: 2026-03-19
+- Repository root: `.`
 
 ## 2. Purpose
 
-This document records the completed unit testing work for Sprint 1. It covers the current implemented Sprint 1 code in the repository, not only the original sprint plan. The goal is to verify that users can:
+This document records the completed unit testing work for the current Sprint 1 implementation in the repository. The scope reflects the latest Sprint 1 codebase rather than the earlier sprint plan only.
+
+The tested Sprint 1 user-facing capabilities are:
 
 - register and log in
-- access authenticated vocabulary features
+- access authenticated learning features
 - view daily words
 - manage word learning progress
 - add, review, update, and remove words in the word bank
+- browse listening levels and lecture clips
+- complete listening practice and submit answers
+- restore saved listening progress for the same authenticated user
+- aggregate profile progress statistics from persisted backend records
 
 ## 3. References
 
-- [project guide.pdf](project guide.pdf)
-- [docs/api-sprint1.md](docs/unit-test-sprint1.md)
-- [backend/tests/test_auth.py](backend/tests/test_auth.py)
-- [backend/tests/test_daily_words.py](backend/tests/test_daily_words.py)
-- [backend/tests/test_word_bank.py](backend/tests/test_word_bank.py)
-- [backend/tests/test_daily_learning.py](backend/tests/test_daily_learning.py)
-- [frontend/src/pages/Login.test.jsx](frontend/src/pages/Login.test.jsx)
-- [frontend/src/pages/Register.test.jsx](frontend/src/pages/Register.test.jsx)
-- [frontend/src/pages/DailyWords.test.jsx](frontend/src/pages/DailyWords.test.jsx)
-- [frontend/src/pages/WordBank.test.jsx](frontend/src/pages/WordBank.test.jsx)
+Project documents referenced in this test document:
+
+- [README.md](../README.md)
+- [docs/api-sprint1.md](./api-sprint1.md)
+- [docs/architecture.md](./architecture.md)
+- [docs/db-schema.md](./db-schema.md)
+- [docs/meetings/sprint1/sprint1_planning.md](./meetings/sprint1/sprint1_planning.md)
 
 ## 4. Features Under Test
 
@@ -38,19 +41,26 @@ Sprint 1 features covered by unit tests:
 1. Authentication
 2. Daily Words API
 3. Word Bank API
-4. Daily Learning API used by current Daily Words and Word Bank pages
-5. Frontend Sprint 1 pages
+4. Daily Learning API used by Daily Words and Word Bank pages
+5. Listening API
+6. Progress Dashboard API
+7. Frontend Sprint 1 pages and shared audio component
 
 Main implementation files:
 
-- [backend/app/routes/auth.py](backend/app/routes/auth.py)
-- [backend/app/routes/daily_words.py](backend/app/routes/daily_words.py)
-- [backend/app/routes/word_bank.py](backend/app/routes/word_bank.py)
-- [backend/app/routes/daily_learning.py](backend/app/routes/daily_learning.py)
-- [frontend/src/pages/Login.jsx](frontend/src/pages/Login.jsx)
-- [frontend/src/pages/Register.jsx](frontend/src/pages/Register.jsx)
-- [frontend/src/pages/DailyWords.jsx](frontend/src/pages/DailyWords.jsx)
-- [frontend/src/pages/WordBank.jsx](frontend/src/pages/WordBank.jsx)
+- [backend/app/routes/auth.py](../backend/app/routes/auth.py)
+- [backend/app/routes/daily_words.py](../backend/app/routes/daily_words.py)
+- [backend/app/routes/word_bank.py](../backend/app/routes/word_bank.py)
+- [backend/app/routes/daily_learning.py](../backend/app/routes/daily_learning.py)
+- [backend/app/routes/listening.py](../backend/app/routes/listening.py)
+- [backend/app/routes/progress.py](../backend/app/routes/progress.py)
+- [frontend/src/pages/Login.jsx](../frontend/src/pages/Login.jsx)
+- [frontend/src/pages/Register.jsx](../frontend/src/pages/Register.jsx)
+- [frontend/src/pages/DailyWords.jsx](../frontend/src/pages/DailyWords.jsx)
+- [frontend/src/pages/WordBank.jsx](../frontend/src/pages/WordBank.jsx)
+- [frontend/src/pages/Listening.jsx](../frontend/src/pages/Listening.jsx)
+- [frontend/src/pages/Profile.jsx](../frontend/src/pages/Profile.jsx)
+- [frontend/src/components/AudioPlayer.jsx](../frontend/src/components/AudioPlayer.jsx)
 
 ## 5. Test Environment and Tools
 
@@ -74,29 +84,35 @@ Main implementation files:
 The unit testing strategy for Sprint 1 is:
 
 - test each API endpoint independently
-- cover happy path, validation failure, duplicate data, and unauthorized access
-- verify JSON response structure and business rules
-- isolate each backend test with a clean test database
+- cover happy path, validation failure, duplicate data, unsupported input, and unauthorized access
+- verify JSON response structure and core business rules
+- isolate backend tests with a clean test database for each test case
 - test frontend pages at component level with mocked API boundaries
-- verify page rendering, validation, submission, and key user actions
+- verify page rendering, validation, submission, navigation, and key user actions
+- retest previously covered Sprint 1 features after integrating the new listening functionality
 
-Backend fixture support is implemented in [backend/tests/conftest.py](backend/tests/conftest.py). Frontend test setup is implemented in [frontend/src/test/setupTests.js](frontend/src/test/setupTests.js) and [frontend/src/test/renderWithProviders.jsx](frontend/src/test/renderWithProviders.jsx).
+Backend fixture support is implemented in [backend/tests/conftest.py](../backend/tests/conftest.py). Frontend test setup is implemented in [frontend/src/test/setupTests.js](../frontend/src/test/setupTests.js) and [frontend/src/test/renderWithProviders.jsx](../frontend/src/test/renderWithProviders.jsx).
 
 ## 7. Implemented Test Files
 
 ### Backend
 
-- [backend/tests/test_auth.py](backend/tests/test_auth.py)
-- [backend/tests/test_daily_words.py](backend/tests/test_daily_words.py)
-- [backend/tests/test_word_bank.py](backend/tests/test_word_bank.py)
-- [backend/tests/test_daily_learning.py](backend/tests/test_daily_learning.py)
+- [backend/tests/test_auth.py](../backend/tests/test_auth.py)
+- [backend/tests/test_daily_words.py](../backend/tests/test_daily_words.py)
+- [backend/tests/test_word_bank.py](../backend/tests/test_word_bank.py)
+- [backend/tests/test_daily_learning.py](../backend/tests/test_daily_learning.py)
+- [backend/tests/test_listening.py](../backend/tests/test_listening.py)
+- [backend/tests/test_progress.py](../backend/tests/test_progress.py)
 
 ### Frontend
 
-- [frontend/src/pages/Login.test.jsx](frontend/src/pages/Login.test.jsx)
-- [frontend/src/pages/Register.test.jsx](frontend/src/pages/Register.test.jsx)
-- [frontend/src/pages/DailyWords.test.jsx](frontend/src/pages/DailyWords.test.jsx)
-- [frontend/src/pages/WordBank.test.jsx](frontend/src/pages/WordBank.test.jsx)
+- [frontend/src/pages/Login.test.jsx](../frontend/src/pages/Login.test.jsx)
+- [frontend/src/pages/Register.test.jsx](../frontend/src/pages/Register.test.jsx)
+- [frontend/src/pages/DailyWords.test.jsx](../frontend/src/pages/DailyWords.test.jsx)
+- [frontend/src/pages/WordBank.test.jsx](../frontend/src/pages/WordBank.test.jsx)
+- [frontend/src/pages/Listening.test.jsx](../frontend/src/pages/Listening.test.jsx)
+- [frontend/src/pages/Profile.test.jsx](../frontend/src/pages/Profile.test.jsx)
+- [frontend/src/components/AudioPlayer.test.jsx](../frontend/src/components/AudioPlayer.test.jsx)
 
 ## 8. Detailed Test Coverage
 
@@ -131,7 +147,7 @@ Covered cases:
 
 Note:
 
-- During test implementation, a real defect was found in [backend/app/routes/daily_words.py](backend/app/routes/daily_words.py) where fewer than 5 source words caused duplicate results. This was fixed so the endpoint now returns only available unique words.
+- During test implementation, a real defect was found in [backend/app/routes/daily_words.py](../backend/app/routes/daily_words.py) where fewer than 5 source words caused duplicate results. This was fixed so the endpoint now returns only available unique words.
 
 ### 8.3 Word Bank API
 
@@ -165,13 +181,41 @@ Covered cases:
 - return review words only
 - return mastered words only
 - return all words with progress status and in-bank flag
+- only search by word text for all-words lookup
 - return learning statistics
 - mark word as mastered
 - reject missing word when marking mastered
 - add word to bank from learning flow
 - reject duplicate add-to-bank request
+- avoid same-day over-assignment after completing carry-over words
+- hide excess same-day pending words when the daily limit is reduced
 
-### 8.5 Frontend Pages
+### 8.5 Listening API
+
+Covered cases:
+
+- return listening catalog with all configured levels
+- expose lecture-clip scenarios for currently supported levels
+- keep unsupported scenarios marked as coming soon
+- stream audio content for an available clip
+- return `404` for unknown audio clip
+- return beginner multiple-choice practice questions
+- reject unsupported level/scenario combinations with coming-soon response
+- return `404` when requested practice material does not exist
+- reject invalid submission payload when `answers` is not an object
+- return intermediate practice results with score, correctness, and transcript
+- persist listening submission results for the current user
+- return saved listening attempt data when the same user revisits a clip
+
+### 8.6 Progress Dashboard API
+
+Covered cases:
+
+- create persisted study-time progress records
+- return real dashboard metrics for words learned, listening done, speaking session count, and total time
+- count listening completions by distinct clip activity rather than raw submission count
+
+### 8.7 Frontend Pages and Components
 
 #### Login Page
 
@@ -199,45 +243,77 @@ Covered cases:
 #### Word Bank Page
 
 - load saved words
-- filter words by search term
+- filter words by word text only
 - refresh word bank list
+
+#### Listening Page
+
+- load listening landing page
+- navigate into a selected level
+- load practice questions for a clip
+- submit beginner multiple-choice answers
+- submit intermediate fill-in-the-blank and short-answer answers
+- render score and transcript after submission
+- preserve answers when switching between clips
+- restore saved listening results after leaving and returning
+- restore saved listening results returned by the backend
+
+#### Profile Page
+
+- load persisted dashboard statistics
+- render words learned, listening completions, speaking sessions, and total time
+
+#### AudioPlayer Component
+
+- toggle play and pause state with mocked media methods
 
 ## 9. Representative Unit Test Cases
 
-The following table provides representative unit test cases in a more standard test case specification format. These cases are selected from the implemented Sprint 1 test suite and focus on the most critical backend and frontend behaviors.
+The following table provides representative unit test cases in a standard test case specification format. These cases are selected from the implemented Sprint 1 test suite and focus on the most important backend and frontend behaviors.
 
 | Test ID | Module / Component | Scenario / Objective | Input / Test Data | Expected Result | Status |
 |---|---|---|---|---|---|
-| AUTH-01 | Authentication API | Verify that a new user can register successfully with valid data | `username=testuser`, `email=test@example.com`, `password=password123` | API returns `201 Created`; user record is stored; password is hashed; returned JSON includes user info | Pass |
-| AUTH-02 | Authentication API | Verify duplicate username handling | Existing user: `testuser`; new request with same username and different email | API returns `409`; error message indicates username already exists | Pass |
-| AUTH-03 | Authentication API | Verify duplicate email handling regardless of case | Existing user email `Test@Example.com`; new request email `test@example.com` | API returns `409`; error message indicates email already registered | Pass |
-| AUTH-04 | Authentication API | Verify successful login with normalized email | Registered user; login input `email=Test@Example.com`, `password=password123` | API returns `200 OK`; authenticated user is returned; session is created | Pass |
-| AUTH-05 | Frontend Login Page | Verify empty-form validation on login page | Click `Sign In` without entering email or password | Validation errors are shown; login API is not called | Pass |
+| AUTH-01 | Authentication API | Verify successful user registration | `username=testuser`, `email=test@example.com`, `password=password123` | API returns `201 Created`; user record is stored; password is hashed; response contains user information | Pass |
+| AUTH-02 | Authentication API | Verify duplicate username handling | Existing user `testuser`; new registration with same username and different email | API returns `409`; error indicates username already exists | Pass |
+| AUTH-03 | Authentication API | Verify duplicate email handling regardless of case | Existing user email `Test@Example.com`; new registration email `test@example.com` | API returns `409`; error indicates email already registered | Pass |
+| AUTH-04 | Authentication API | Verify successful login with normalized email | Registered user; login input `email=Test@Example.com`, `password=password123` | API returns `200 OK`; authenticated user is returned and session is created | Pass |
+| AUTH-05 | Frontend Login Page | Verify empty-form validation | Click `Sign In` without entering email or password | Validation errors are displayed; login API is not called | Pass |
 | AUTH-06 | Frontend Register Page | Verify password confirmation validation | `password=password123`, `confirmPassword=password456` | Validation error `Passwords do not match`; register API is not called | Pass |
 | DW-01 | Daily Words API | Verify behavior when no words exist in database | Empty `words` table; request `GET /api/daily-words` | API returns `200 OK`; `words` is an empty array | Pass |
-| DW-02 | Daily Words API | Verify unique results when total word count is below five | Database contains 3 words; request `GET /api/daily-words?date=2026-03-18` | API returns exactly the 3 available unique words without duplication | Pass |
-| DW-03 | Daily Words API | Verify deterministic selection for the same date | Same request date sent twice with populated word table | Both responses contain the same selected word set | Pass |
-| DW-04 | Frontend Daily Words Page | Verify daily word summary renders correctly | Mock API response with `date=2026-03-18`, `1` pending word, `2` review words, `1` mastered word | Page displays date and correct summary counts | Pass |
-| WB-01 | Word Bank API | Verify adding a word by `word_id` | Authenticated user; existing word `id=1`; request `POST /api/word-bank` with `word_id=1` | API returns `201 Created`; word bank entry is stored and returned | Pass |
-| WB-02 | Word Bank API | Verify duplicate add protection | Same authenticated user adds same `word_id` twice | Second request returns `409`; error indicates word already in bank | Pass |
-| WB-03 | Word Bank API | Verify deletion of existing word bank entry | Authenticated user; existing entry id | API returns `200 OK`; entry is removed from database | Pass |
-| WB-04 | Word Bank API | Verify mastery update validation | Authenticated user; request `PATCH /api/word-bank/<id>` with `mastery_level=4` | API returns `400`; error indicates invalid mastery level | Pass |
-| WB-05 | Word Bank API | Verify review action updates mastery and history | Authenticated user; entry with `mastery_level=1`; request review with `knew_it=true` | API returns `200 OK`; mastery becomes `2`; review history record is created | Pass |
-| WB-06 | Frontend Word Bank Page | Verify saved word list is rendered and searchable | Mock word bank contains `hypothesis` and `empirical`; search keyword `hypo` | Page filters results and only matching word remains visible | Pass |
-| WB-07 | Frontend Word Bank Page | Verify refresh action reloads word bank data | First mocked response empty; second mocked response contains `rubric`; click `Refresh` | Page reloads data and displays updated word list | Pass |
+| DW-02 | Daily Words API | Verify unique results when word count is below five | Database contains 3 words; request `GET /api/daily-words?date=2026-03-18` | API returns exactly the 3 available unique words without duplication | Pass |
+| DW-03 | Frontend Daily Words Page | Verify daily word summary rendering | Mock response with `date=2026-03-18`, `1` pending word, `2` review words, `1` mastered word | Page displays date and correct summary counts | Pass |
+| WB-01 | Word Bank API | Verify adding a word by `word_id` | Authenticated user; request `POST /api/word-bank` with an existing `word_id` | API returns `201 Created`; word bank entry is stored and returned | Pass |
+| WB-02 | Word Bank API | Verify duplicate add protection | Same authenticated user adds the same `word_id` twice | Second request returns `409`; error indicates word already in bank | Pass |
+| WB-03 | Word Bank API | Verify review action updates mastery and history | Authenticated user; entry with `mastery_level=1`; request review with `knew_it=true` | API returns `200 OK`; mastery becomes `2`; review history record is created | Pass |
+| WB-04 | Frontend Word Bank Page | Verify search filtering | Mock word bank contains `hypothesis` and `empirical`; search keyword `hypo` | Only matching word remains visible after filtering | Pass |
+| DL-01 | Daily Learning API | Verify same-day limit is not refilled after carry-over is completed | User completes carry-over words and re-requests `/daily-learning/today` with same limit | API returns no new pending words beyond the configured daily cap | Pass |
+| DL-02 | Daily Learning API | Verify reducing daily limit hides excess same-day pending words | User expands from `10` to `20`, receives more words, then reduces back to `10` | API hides the extra same-day pending words and returns no additional today list items | Pass |
+| LISTEN-01 | Listening API | Verify listening catalog structure | Authenticated request `GET /api/listening/clips` | API returns level list, scenario list, supported lecture clips, and audio URLs | Pass |
+| LISTEN-02 | Listening API | Verify beginner practice question format | Authenticated request for beginner lecture practice | API returns beginner questions as multiple choice only; no answers are exposed in public payload | Pass |
+| LISTEN-03 | Listening API | Verify intermediate practice submission grading | Submit intermediate answers to quiz endpoint | API returns score, correct count, per-question results, and transcript | Pass |
+| LISTEN-04 | Listening API | Verify invalid submission payload handling | Submit listening answers as an array instead of an object | API returns `400`; error indicates answers must be provided as an object | Pass |
+| LISTEN-05 | Listening API | Verify unsupported practice path handling | Request `beginner/group-discussion` or submit `advanced/lecture-clips` practice | API returns `404`; error indicates the practice path is coming soon | Pass |
+| LISTEN-06 | Listening API | Verify saved listening progress is returned for the same user | Submit answers, then request the same clip again while logged in as the same user | API returns `saved_attempt` with prior answers and graded results | Pass |
+| PROG-01 | Progress Dashboard API | Verify dashboard metrics aggregation | Authenticated user with word progress, listening records, study time, and speaking session rows | API returns correct words learned, distinct listening completions, speaking session count, and total time | Pass |
+| PROG-02 | Frontend Profile Page | Verify persisted profile statistics rendering | Mock dashboard response with live counts and time | Profile page renders the returned values correctly | Pass |
+| LISTEN-07 | Frontend Listening Page | Verify level navigation and practice loading | Open `/listening`, click `Beginner` | Page navigates to level detail and loads beginner practice questions | Pass |
+| LISTEN-08 | Frontend Listening Page | Verify beginner submission flow | Select beginner answers and click `Submit answers` | Submission API is called; page shows score and transcript | Pass |
+| LISTEN-09 | Frontend Listening Page | Verify answer/result restoration after switching clips | Submit one clip, switch to another clip, then switch back | Previous answers and graded results are restored | Pass |
+| LISTEN-10 | Frontend Listening Page | Verify backend-saved listening results are restored | Listening practice payload includes `saved_attempt` | Page restores prior answers and score without requiring local cache only | Pass |
+| AUDIO-01 | AudioPlayer Component | Verify playback toggle behavior | Render player with valid `src`, click play button twice | First click calls `play`, second click calls `pause`, component toggles playback state | Pass |
 
 ## 10. Execution Commands
 
 ### Backend
 
 ```bash
-PYTHONPATH="/tmp/bot0_pydeps:/Users/huruoqi/Desktop/BOT_0/backend" python3 -m pytest backend/tests -q
+pytest backend/tests
 ```
 
-Coverage command used for verification:
+Coverage command:
 
 ```bash
-PYTHONPATH="/tmp/bot0_pydeps:/Users/huruoqi/Desktop/BOT_0/backend" python3 -m pytest backend/tests --cov=app --cov-report=term-missing
+pytest backend/tests --cov=backend/app --cov-report=term-missing
 ```
 
 ### Frontend
@@ -251,70 +327,84 @@ npm test
 
 ### Backend Result
 
-Execution date: 2026-03-18
+Execution date: 2026-03-19
 
-- `47` tests passed
+- `62` tests passed
 - `0` tests failed
 - backend app total coverage: `90%`
 
 Important Sprint 1 route coverage from the coverage report:
 
 - `auth.py`: `91%`
-- `daily_learning.py`: `95%`
+- `daily_learning.py`: `96%`
 - `daily_words.py`: `100%`
 - `word_bank.py`: `98%`
+- `listening.py`: `88%`
+- `progress.py`: `91%`
 
 ### Frontend Result
 
-Execution date: 2026-03-18
+Execution date: 2026-03-19
 
-- `4` test files passed
-- `8` tests passed
+- `7` test files passed
+- `17` tests passed
 - `0` tests failed
 
-Covered Sprint 1 frontend pages:
+Covered Sprint 1 frontend pages and components:
 
 - Login
 - Register
 - DailyWords
 - WordBank
+- Listening
+- Profile
+- AudioPlayer
 
 ## 12. Coverage Assessment
 
-Sprint 1 feature coverage is now complete for the current implemented functionality in this repository.
+Sprint 1 feature coverage is complete for the current implemented Sprint 1 functionality in this repository.
 
 ### Fully Covered
 
 - authentication backend logic
 - daily words backend logic
 - word bank backend logic
-- daily learning backend logic currently used by Sprint 1 pages
-- core frontend page behavior for login, register, daily words, and word bank
+- daily learning backend logic used by vocabulary pages
+- listening backend logic for currently supported flows
+- persisted listening-attempt restore logic for the same user
+- progress dashboard aggregation logic
+- listening backend error handling for unsupported and invalid requests
+- core frontend behavior for login, register, daily words, word bank, listening, profile, and audio playback
 
 ### Residual Gaps
 
 - Some non-Sprint-1 models and AI service code remain outside Sprint 1 scope and reduce global application coverage
-- Current frontend tests focus on main user flows rather than every UI branch
+- The listening route includes multiple parsing and fallback branches that are only partially exercised because some scenarios are intentionally marked as coming soon
+- Current frontend tests focus on main user flows rather than every visual branch
 
 These residual gaps do not affect Sprint 1 feature completeness.
 
 ## 13. Risks and Notes
 
-1. Backend test execution currently relies on installed Python dependencies. For this verification run, dependencies were installed into `/tmp/bot0_pydeps`.
-2. Coverage output shows SQLAlchemy `Query.get()` legacy warnings in existing route code. These warnings do not break tests but should be refactored later to `db.session.get(...)`.
-3. Ant Design emits deprecation warnings during frontend tests, but all Sprint 1 tests still pass successfully.
+1. Coverage output shows SQLAlchemy `Query.get()` legacy warnings in existing route code. These warnings do not break tests but should later be refactored to `db.session.get(...)`.
+2. Ant Design emits deprecation warnings during frontend tests, but all tested UI flows still pass successfully.
+3. Vitest emits a benign localstorage-file warning in this environment; it did not cause test failures.
+4. Listening content depends on the project’s `Audio`, `output`, and `generated_questions_md` folders being present and aligned by source name.
 
 ## 14. Final Evaluation
 
 Sprint 1 unit testing is complete for the current implemented Sprint 1 functionality.
 
-- Backend tests cover all current Sprint 1 APIs and related learning flows.
-- Frontend tests cover all current Sprint 1 pages.
-- All newly added backend and frontend tests pass.
-- A real defect in the daily words API was identified and fixed during testing.
+- Backend tests cover all current Sprint 1 APIs and listening flows.
+- Frontend tests cover all current Sprint 1 pages, the profile dashboard page, and the shared audio player.
+- Previously implemented vocabulary tests were re-run after the listening integration.
+- All backend and frontend tests pass on the latest codebase.
+- Additional listening persistence tests were added for saved-attempt restoration and clip-switch continuity.
+- Additional daily-learning tests were added for daily-limit adjustment edge cases.
+- Additional progress tests were added for dashboard aggregation and persisted study-time records.
 
 Final status:
 
-- Backend: `47/47` tests passed
-- Frontend: `8/8` tests passed
+- Backend: `62/62` tests passed
+- Frontend: `17/17` tests passed
 - Backend application coverage: `90%`

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -97,10 +97,10 @@ export default function App() {
                 <RequireAuth user={user} loading={loading}><WordBank /></RequireAuth>
               } />
               <Route path="/listening" element={
-                <RequireAuth user={user} loading={loading}><Listening /></RequireAuth>
+                <RequireAuth user={user} loading={loading}><Listening user={user} /></RequireAuth>
               } />
               <Route path="/listening/:levelId" element={
-                <RequireAuth user={user} loading={loading}><Listening /></RequireAuth>
+                <RequireAuth user={user} loading={loading}><Listening user={user} /></RequireAuth>
               } />
               <Route path="/speaking" element={
                 <RequireAuth user={user} loading={loading}><Speaking /></RequireAuth>

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -56,8 +56,16 @@ export const listeningAPI = {
   getCatalog: () => api.get('/listening/clips'),
   getPractice: (levelId, scenarioId, sourceSlug) =>
     api.get(`/listening/quiz/${levelId}/${scenarioId}/${sourceSlug}`),
-  submitPractice: (levelId, scenarioId, sourceSlug, answers) =>
-    api.post(`/listening/quiz/${levelId}/${scenarioId}/${sourceSlug}/submit`, { answers }),
+  submitPractice: (levelId, scenarioId, sourceSlug, answers, timeSpent) =>
+    api.post(`/listening/quiz/${levelId}/${scenarioId}/${sourceSlug}/submit`, {
+      answers,
+      time_spent: timeSpent,
+    }),
+};
+
+export const progressAPI = {
+  getDashboard: () => api.get('/progress/dashboard'),
+  trackTime: (payload) => api.post('/progress/track-time', payload),
 };
 
 export default api;

--- a/frontend/src/hooks/useLearningTimeTracker.js
+++ b/frontend/src/hooks/useLearningTimeTracker.js
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { progressAPI } from '../api';
+
+const apiBaseURL = import.meta.env.DEV
+  ? '/api'
+  : (import.meta.env.VITE_API_BASE_URL || '/api');
+
+export default function useLearningTimeTracker(module, activityType) {
+  const startedAtRef = useRef(Date.now());
+  const accumulatedMsRef = useRef(0);
+
+  useEffect(() => {
+    if (!module || !activityType) {
+      return undefined;
+    }
+
+    const flushTrackedTime = (useBeacon = false) => {
+      const now = Date.now();
+      accumulatedMsRef.current += Math.max(0, now - startedAtRef.current);
+      startedAtRef.current = now;
+
+      const minutes = useBeacon
+        ? Math.ceil(accumulatedMsRef.current / 60000)
+        : Math.floor(accumulatedMsRef.current / 60000);
+
+      if (minutes <= 0) {
+        return;
+      }
+
+      accumulatedMsRef.current -= minutes * 60000;
+      const payload = {
+        module,
+        activity_type: activityType,
+        time_spent: minutes,
+      };
+
+      if (useBeacon && typeof navigator !== 'undefined' && navigator.sendBeacon) {
+        const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+        navigator.sendBeacon(`${apiBaseURL}/progress/track-time`, blob);
+        return;
+      }
+
+      const request = progressAPI.trackTime(payload);
+      if (request && typeof request.catch === 'function') {
+        request.catch((error) => {
+          console.error('Failed to track learning time:', error);
+        });
+      }
+    };
+
+    const intervalId = window.setInterval(() => flushTrackedTime(false), 30000);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        flushTrackedTime(true);
+      } else {
+        startedAtRef.current = Date.now();
+      }
+    };
+
+    const handlePageHide = () => {
+      flushTrackedTime(true);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
+      flushTrackedTime(true);
+    };
+  }, [activityType, module]);
+}

--- a/frontend/src/pages/AIChat.jsx
+++ b/frontend/src/pages/AIChat.jsx
@@ -1,5 +1,6 @@
 import { Typography, Card, Row, Col, Tag } from 'antd';
 import { RobotOutlined, TeamOutlined, CommentOutlined } from '@ant-design/icons';
+import useLearningTimeTracker from '../hooks/useLearningTimeTracker';
 
 const { Title, Text } = Typography;
 
@@ -10,7 +11,7 @@ const scenarios = [
     color: '#2563eb',
     bg: '#eff6ff',
     desc: 'Practice asking your professor for help, clarifying assignment requirements, and discussing grades.',
-    sprint: 'Sprint 3',
+    status: 'Coming soon',
   },
   {
     title: 'Seminar Discussion',
@@ -18,7 +19,7 @@ const scenarios = [
     color: '#7c3aed',
     bg: '#f5f3ff',
     desc: 'Participate in academic group discussions, express agreement/disagreement, and build on ideas.',
-    sprint: 'Sprint 3',
+    status: 'Coming soon',
   },
   {
     title: 'Free Conversation',
@@ -26,11 +27,13 @@ const scenarios = [
     color: '#059669',
     bg: '#ecfdf5',
     desc: 'Choose any topic and practice open-ended academic conversation with AI.',
-    sprint: 'Sprint 4 (Bonus)',
+    status: 'Coming soon',
   },
 ];
 
 export default function AIChat() {
+  useLearningTimeTracker('chat', 'study_time:ai-chat');
+
   return (
     <div className="page-container">
       <div className="page-header">
@@ -69,7 +72,7 @@ export default function AIChat() {
                 {s.icon}
               </div>
               <Title level={5} style={{ fontWeight: 600 }}>{s.title}</Title>
-              <Tag style={{ borderRadius: 12, marginBottom: 12 }}>{s.sprint}</Tag>
+              <Tag style={{ borderRadius: 12, marginBottom: 12 }}>{s.status}</Tag>
               <Text type="secondary" style={{ fontSize: 13, display: 'block' }}>
                 {s.desc}
               </Text>

--- a/frontend/src/pages/DailyWords.jsx
+++ b/frontend/src/pages/DailyWords.jsx
@@ -10,6 +10,7 @@ import {
   ReloadOutlined, TrophyOutlined, SearchOutlined, StarOutlined
 } from '@ant-design/icons';
 import { dailyLearningAPI, wordBankAPI } from '../api';
+import useLearningTimeTracker from '../hooks/useLearningTimeTracker';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -17,6 +18,8 @@ const DAILY_COUNT_KEY = 'dailyWordsCount';
 const DEFAULT_COUNT = 10;
 
 export default function DailyWords() {
+  useLearningTimeTracker('vocab', 'study_time:daily-words');
+
   // Main state
   const [todayWords, setTodayWords] = useState([]);
   const [reviewCount, setReviewCount] = useState(0);

--- a/frontend/src/pages/DailyWords.test.jsx
+++ b/frontend/src/pages/DailyWords.test.jsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DailyWords from './DailyWords';
 import { renderWithProviders } from '../test/renderWithProviders';
 
-const { mockDailyLearningAPI, mockWordBankAPI } = vi.hoisted(() => ({
+const { mockDailyLearningAPI, mockWordBankAPI, mockProgressAPI } = vi.hoisted(() => ({
   mockDailyLearningAPI: {
     getToday: vi.fn(),
     updateWordStatus: vi.fn(),
@@ -19,17 +19,23 @@ const { mockDailyLearningAPI, mockWordBankAPI } = vi.hoisted(() => ({
   mockWordBankAPI: {
     getAll: vi.fn(),
   },
+  mockProgressAPI: {
+    getDashboard: vi.fn(),
+    trackTime: vi.fn(),
+  },
 }));
 
 vi.mock('../api', () => ({
   dailyLearningAPI: mockDailyLearningAPI,
   wordBankAPI: mockWordBankAPI,
+  progressAPI: mockProgressAPI,
 }));
 
 describe('DailyWords page', () => {
   beforeEach(() => {
     Object.values(mockDailyLearningAPI).forEach((fn) => fn.mockReset());
     Object.values(mockWordBankAPI).forEach((fn) => fn.mockReset());
+    Object.values(mockProgressAPI).forEach((fn) => fn.mockReset());
     localStorage.clear();
   });
 

--- a/frontend/src/pages/Listening.jsx
+++ b/frontend/src/pages/Listening.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Button,
@@ -29,6 +29,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import AudioPlayer from '../components/AudioPlayer';
 import { listeningAPI } from '../api';
+import useLearningTimeTracker from '../hooks/useLearningTimeTracker';
 
 const { Title, Text, Paragraph } = Typography;
 const { TextArea } = Input;
@@ -52,6 +53,53 @@ const questionTypeLabels = {
   short_answer: 'Short answer',
 };
 
+function getListeningStorageKey(userId) {
+  return `listening-practice-state-v1:${userId || 'anonymous'}`;
+}
+
+function loadPersistedListeningState(userId) {
+  if (typeof window === 'undefined') {
+    return {
+      answerCache: {},
+      submissionCache: {},
+      timeSpentCache: {},
+    };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(getListeningStorageKey(userId));
+    if (!raw) {
+      return {
+        answerCache: {},
+        submissionCache: {},
+        timeSpentCache: {},
+      };
+    }
+
+    const parsed = JSON.parse(raw);
+    return {
+      answerCache: parsed.answerCache || {},
+      submissionCache: parsed.submissionCache || {},
+      timeSpentCache: parsed.timeSpentCache || {},
+    };
+  } catch (error) {
+    console.error('Failed to restore listening practice state:', error);
+    return {
+      answerCache: {},
+      submissionCache: {},
+      timeSpentCache: {},
+    };
+  }
+}
+
+function persistListeningState(userId, state) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(getListeningStorageKey(userId), JSON.stringify(state));
+}
+
 function handleSelectableKeyDown(event, onSelect) {
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault();
@@ -66,7 +114,9 @@ function createEmptyAnswers(questions) {
   }, {});
 }
 
-export default function Listening() {
+export default function Listening({ user }) {
+  useLearningTimeTracker('listening', 'study_time:listening');
+
   const navigate = useNavigate();
   const { levelId } = useParams();
 
@@ -79,8 +129,27 @@ export default function Listening() {
   const [practiceError, setPracticeError] = useState('');
   const [practiceData, setPracticeData] = useState(null);
   const [answers, setAnswers] = useState({});
+  const [answerCache, setAnswerCache] = useState(() => loadPersistedListeningState(user?.id).answerCache);
   const [submitting, setSubmitting] = useState(false);
   const [submissionResult, setSubmissionResult] = useState(null);
+  const [submissionCache, setSubmissionCache] = useState(
+    () => loadPersistedListeningState(user?.id).submissionCache
+  );
+  const [timeSpentCache, setTimeSpentCache] = useState(
+    () => loadPersistedListeningState(user?.id).timeSpentCache
+  );
+  const practiceStartedAtRef = useRef(null);
+  const activePracticeKeyRef = useRef(null);
+  const answerCacheRef = useRef(answerCache);
+  const submissionCacheRef = useRef(submissionCache);
+  const timeSpentCacheRef = useRef(timeSpentCache);
+
+  useEffect(() => {
+    const persistedState = loadPersistedListeningState(user?.id);
+    setAnswerCache(persistedState.answerCache || {});
+    setSubmissionCache(persistedState.submissionCache || {});
+    setTimeSpentCache(persistedState.timeSpentCache || {});
+  }, [user?.id]);
 
   useEffect(() => {
     let active = true;
@@ -116,10 +185,24 @@ export default function Listening() {
     (scenario) => scenario.id === selectedScenarioId
   ) || null;
   const selectedClip = selectedScenario?.clips?.find((clip) => clip.id === selectedClipId) || null;
+  const selectedPracticeKey = selectedLevel && selectedScenario && selectedClip
+    ? `${selectedLevel.id}:${selectedScenario.id}:${selectedClip.source_slug}`
+    : null;
   const resultMap = (submissionResult?.results || []).reduce((accumulator, result) => {
     accumulator[result.id] = result;
     return accumulator;
   }, {});
+
+  useEffect(() => {
+    answerCacheRef.current = answerCache;
+    submissionCacheRef.current = submissionCache;
+    timeSpentCacheRef.current = timeSpentCache;
+    persistListeningState(user?.id, {
+      answerCache,
+      submissionCache,
+      timeSpentCache,
+    });
+  }, [answerCache, submissionCache, timeSpentCache, user?.id]);
 
   useEffect(() => {
     if (!levelId || !selectedLevel?.scenarios?.length) {
@@ -183,7 +266,22 @@ export default function Listening() {
         );
         if (!active) return;
         setPracticeData(response.data);
-        setAnswers(createEmptyAnswers(response.data.questions));
+        const emptyAnswers = createEmptyAnswers(response.data.questions);
+        const savedAttempt = response.data.saved_attempt;
+        const savedAnswers = savedAttempt?.answers || {};
+        const cachedAnswers = selectedPracticeKey ? answerCache[selectedPracticeKey] : null;
+        setAnswers({ ...emptyAnswers, ...savedAnswers, ...(cachedAnswers || {}) });
+
+        const savedSubmission = savedAttempt ? {
+          score: savedAttempt.score,
+          correct_count: savedAttempt.correct_count,
+          total_count: savedAttempt.total_count,
+          results: savedAttempt.results,
+          transcript: savedAttempt.transcript,
+        } : null;
+        setSubmissionResult(
+          selectedPracticeKey ? (submissionCache[selectedPracticeKey] || savedSubmission) : savedSubmission
+        );
       } catch (fetchError) {
         console.error('Failed to load listening practice:', fetchError);
         if (!active) return;
@@ -203,11 +301,59 @@ export default function Listening() {
     };
   }, [levelId, selectedLevel, selectedScenario, selectedClip]);
 
+  useEffect(() => {
+    const flushActivePracticeTime = () => {
+      const activeKey = activePracticeKeyRef.current;
+      const startedAt = practiceStartedAtRef.current;
+      if (!activeKey || !startedAt) {
+        return;
+      }
+
+      const elapsedMs = Math.max(0, Date.now() - startedAt);
+      if (elapsedMs > 0) {
+        const nextTimeSpentCache = {
+          ...timeSpentCacheRef.current,
+          [activeKey]: (timeSpentCacheRef.current[activeKey] || 0) + elapsedMs,
+        };
+        timeSpentCacheRef.current = nextTimeSpentCache;
+        persistListeningState({
+          answerCache: answerCacheRef.current,
+          submissionCache: submissionCacheRef.current,
+          timeSpentCache: nextTimeSpentCache,
+        });
+        setTimeSpentCache(nextTimeSpentCache);
+      }
+
+      practiceStartedAtRef.current = null;
+      activePracticeKeyRef.current = null;
+    };
+
+    flushActivePracticeTime();
+
+    if (selectedPracticeKey && !submissionCache[selectedPracticeKey]) {
+      activePracticeKeyRef.current = selectedPracticeKey;
+      practiceStartedAtRef.current = Date.now();
+    }
+
+    return () => {
+      flushActivePracticeTime();
+    };
+  }, [selectedPracticeKey, submissionCache, user?.id]);
+
   const handleAnswerChange = (questionId, value) => {
-    setAnswers((currentAnswers) => ({
-      ...currentAnswers,
-      [questionId]: value,
-    }));
+    setAnswers((currentAnswers) => {
+      const nextAnswers = {
+        ...currentAnswers,
+        [questionId]: value,
+      };
+      if (selectedPracticeKey) {
+        setAnswerCache((currentCache) => ({
+          ...currentCache,
+          [selectedPracticeKey]: nextAnswers,
+        }));
+      }
+      return nextAnswers;
+    });
   };
 
   const handleSubmit = async () => {
@@ -225,6 +371,14 @@ export default function Listening() {
         answers
       );
       setSubmissionResult(response.data);
+      if (selectedPracticeKey) {
+        activePracticeKeyRef.current = null;
+        practiceStartedAtRef.current = null;
+        setSubmissionCache((currentCache) => ({
+          ...currentCache,
+          [selectedPracticeKey]: response.data,
+        }));
+      }
     } catch (submitError) {
       console.error('Failed to submit listening practice:', submitError);
       setPracticeError('We could not submit your answers. Please try again.');
@@ -234,7 +388,25 @@ export default function Listening() {
   };
 
   const handleResetCurrentClip = () => {
-    setAnswers(createEmptyAnswers(practiceData?.questions));
+    const resetAnswers = createEmptyAnswers(practiceData?.questions);
+    setAnswers(resetAnswers);
+    if (selectedPracticeKey) {
+      activePracticeKeyRef.current = selectedPracticeKey;
+      practiceStartedAtRef.current = Date.now();
+      setAnswerCache((currentCache) => ({
+        ...currentCache,
+        [selectedPracticeKey]: resetAnswers,
+      }));
+      setSubmissionCache((currentCache) => {
+        const nextCache = { ...currentCache };
+        delete nextCache[selectedPracticeKey];
+        return nextCache;
+      });
+      setTimeSpentCache((currentCache) => ({
+        ...currentCache,
+        [selectedPracticeKey]: 0,
+      }));
+    }
     setSubmissionResult(null);
     setPracticeError('');
   };
@@ -766,7 +938,7 @@ export default function Listening() {
                 color={selectedLevel.is_available ? 'success' : 'default'}
                 style={{ borderRadius: 999 }}
               >
-                {selectedLevel.is_available ? 'Lecture Clips available now' : 'In development'}
+                {selectedLevel.is_available ? 'Lecture Clips available now' : 'Coming soon'}
               </Tag>
             </Space>
 

--- a/frontend/src/pages/Listening.test.jsx
+++ b/frontend/src/pages/Listening.test.jsx
@@ -6,16 +6,21 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import Listening from './Listening';
 
-const { mockListeningAPI } = vi.hoisted(() => ({
+const { mockListeningAPI, mockProgressAPI } = vi.hoisted(() => ({
   mockListeningAPI: {
     getCatalog: vi.fn(),
     getPractice: vi.fn(),
     submitPractice: vi.fn(),
   },
+  mockProgressAPI: {
+    getDashboard: vi.fn(),
+    trackTime: vi.fn(),
+  },
 }));
 
 vi.mock('../api', () => ({
   listeningAPI: mockListeningAPI,
+  progressAPI: mockProgressAPI,
 }));
 
 const catalogPayload = {
@@ -193,6 +198,7 @@ const beginnerPracticePayload = {
   },
   instructions: 'Listen to the lecture clip and answer the multiple-choice questions.',
   question_count: 2,
+  saved_attempt: null,
   questions: [
     {
       id: 'beginner-campus-welcome-multiple-choice-1',
@@ -218,6 +224,35 @@ const beginnerPracticePayload = {
         { key: 'B', text: 'Campus orientation' },
         { key: 'C', text: 'Dining hall menus' },
         { key: 'D', text: 'Scholarship forms' },
+      ],
+    },
+  ],
+};
+
+const libraryPracticePayload = {
+  level: { id: 'beginner', label: 'Beginner' },
+  scenario: { id: 'lecture-clips', label: 'Lecture Clips' },
+  clip: {
+    id: 'beginner-lecture-library-tour',
+    title: 'Library Orientation',
+    audio_url: '/api/listening/audio/library-tour',
+    source_slug: 'library-tour',
+  },
+  instructions: 'Listen to the lecture clip and answer the multiple-choice questions.',
+  question_count: 1,
+  saved_attempt: null,
+  questions: [
+    {
+      id: 'beginner-library-tour-multiple-choice-1',
+      number: 1,
+      type: 'multiple_choice',
+      section_label: 'Multiple choice',
+      prompt: 'Who leads the library tour?',
+      options: [
+        { key: 'A', text: 'A professor' },
+        { key: 'B', text: 'A librarian' },
+        { key: 'C', text: 'A classmate' },
+        { key: 'D', text: 'A coach' },
       ],
     },
   ],
@@ -269,6 +304,7 @@ const intermediatePracticePayload = {
   },
   instructions: 'Listen carefully, then complete the fill-in-the-blank and short-answer tasks.',
   question_count: 2,
+  saved_attempt: null,
   questions: [
     {
       id: 'intermediate-research-fill-1',
@@ -333,14 +369,22 @@ function renderListening(initialEntry = '/listening') {
 
 describe('Listening page', () => {
   beforeEach(() => {
+    window.localStorage.clear();
     mockListeningAPI.getCatalog.mockReset();
     mockListeningAPI.getPractice.mockReset();
     mockListeningAPI.submitPractice.mockReset();
+    mockProgressAPI.trackTime.mockReset();
 
     mockListeningAPI.getCatalog.mockResolvedValue({ data: catalogPayload });
-    mockListeningAPI.getPractice.mockImplementation((levelId) => Promise.resolve({
-      data: levelId === 'intermediate' ? intermediatePracticePayload : beginnerPracticePayload,
-    }));
+    mockListeningAPI.getPractice.mockImplementation((levelId, _scenarioId, sourceSlug) => {
+      if (levelId === 'intermediate') {
+        return Promise.resolve({ data: intermediatePracticePayload });
+      }
+      if (sourceSlug === 'library-tour') {
+        return Promise.resolve({ data: libraryPracticePayload });
+      }
+      return Promise.resolve({ data: beginnerPracticePayload });
+    });
     mockListeningAPI.submitPractice.mockImplementation((levelId) => Promise.resolve({
       data: levelId === 'intermediate' ? intermediateSubmitPayload : beginnerSubmitPayload,
     }));
@@ -431,5 +475,76 @@ describe('Listening page', () => {
       screen.getAllByText('Because they reveal different kinds of evidence.').length
     ).toBeGreaterThan(0);
     expect(screen.getByText(/Research begins with a clear question/)).toBeTruthy();
+  });
+
+  it('preserves answers when switching between clips and restores prior submission results', async () => {
+    renderListening('/listening/beginner');
+
+    expect(await screen.findByText('Who is speaking at the start of the lecture?')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('A. A student ambassador'));
+    fireEvent.click(screen.getByText('D. Scholarship forms'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit answers' }));
+
+    expect(await screen.findByText((_, node) => node?.textContent === '50%')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Library Orientation'));
+    expect(await screen.findByText('Who leads the library tour?')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Campus Welcome Lecture'));
+    expect(await screen.findByText('Who is speaking at the start of the lecture?')).toBeTruthy();
+    expect(screen.getByText((_, node) => node?.textContent === '50%')).toBeTruthy();
+
+    const selectedOption = document.querySelector('input[value="A"]');
+    expect(selectedOption?.checked).toBe(true);
+  });
+
+  it('restores saved answers and results after leaving the page and coming back', async () => {
+    const firstRender = renderListening('/listening/beginner');
+
+    expect(await screen.findByText('Who is speaking at the start of the lecture?')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('A. A student ambassador'));
+    fireEvent.click(screen.getByText('D. Scholarship forms'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit answers' }));
+
+    expect(await screen.findByText((_, node) => node?.textContent === '50%')).toBeTruthy();
+
+    firstRender.unmount();
+
+    renderListening('/listening/beginner');
+
+    expect(await screen.findByText('Who is speaking at the start of the lecture?')).toBeTruthy();
+    expect(await screen.findByText((_, node) => node?.textContent === '50%')).toBeTruthy();
+
+    const selectedOption = document.querySelector('input[value="A"]');
+    expect(selectedOption?.checked).toBe(true);
+  });
+
+  it('restores saved submission data returned by the backend', async () => {
+    mockListeningAPI.getPractice.mockResolvedValueOnce({
+      data: {
+        ...beginnerPracticePayload,
+        saved_attempt: {
+          answers: {
+            'beginner-campus-welcome-multiple-choice-1': 'A',
+            'beginner-campus-welcome-multiple-choice-2': 'D',
+          },
+          score: 50,
+          correct_count: 1,
+          total_count: 2,
+          transcript: beginnerSubmitPayload.transcript,
+          results: beginnerSubmitPayload.results,
+        },
+      },
+    });
+
+    renderListening('/listening/beginner');
+
+    expect(await screen.findByText('Who is speaking at the start of the lecture?')).toBeTruthy();
+    expect(await screen.findByText((_, node) => node?.textContent === '50%')).toBeTruthy();
+
+    const selectedOption = document.querySelector('input[value="A"]');
+    expect(selectedOption?.checked).toBe(true);
   });
 });

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from 'react';
 import { Typography, Card, Row, Col, Avatar, Statistic, Tag } from 'antd';
 import {
   UserOutlined,
@@ -6,10 +7,46 @@ import {
   AudioOutlined,
   ClockCircleOutlined,
 } from '@ant-design/icons';
+import { progressAPI } from '../api';
 
 const { Title, Text } = Typography;
 
 export default function Profile({ user }) {
+  const [stats, setStats] = useState({
+    wordsLearned: 0,
+    listeningDone: 0,
+    speakingSessions: 0,
+    totalTimeMinutes: 0,
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    const fetchStats = async () => {
+      try {
+        const response = await progressAPI.getDashboard();
+        if (!active) {
+          return;
+        }
+        setStats({
+          wordsLearned: response.data.words_learned || 0,
+          listeningDone: response.data.listening_done || 0,
+          speakingSessions: response.data.speaking_sessions || 0,
+          totalTimeMinutes: response.data.total_time_minutes || 0,
+        });
+      } catch (error) {
+        console.error('Failed to load profile progress:', error);
+      }
+    };
+
+    fetchStats();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const totalHours = `${(stats.totalTimeMinutes / 60).toFixed(1)}h`;
+
   return (
     <div className="page-container">
       {/* Profile card */}
@@ -38,16 +75,16 @@ export default function Profile({ user }) {
         <div style={{ padding: '24px 32px' }}>
           <Row gutter={24}>
             <Col span={6}>
-              <Statistic title="Words Learned" value={0} prefix={<BookOutlined />} />
+              <Statistic title="Words Learned" value={stats.wordsLearned} prefix={<BookOutlined />} />
             </Col>
             <Col span={6}>
-              <Statistic title="Listening Done" value={0} prefix={<SoundOutlined />} />
+              <Statistic title="Listening Done" value={stats.listeningDone} prefix={<SoundOutlined />} />
             </Col>
             <Col span={6}>
-              <Statistic title="Speaking Sessions" value={0} prefix={<AudioOutlined />} />
+              <Statistic title="Speaking Sessions" value={stats.speakingSessions} prefix={<AudioOutlined />} />
             </Col>
             <Col span={6}>
-              <Statistic title="Total Time" value="0h" prefix={<ClockCircleOutlined />} />
+              <Statistic title="Total Time" value={totalHours} prefix={<ClockCircleOutlined />} />
             </Col>
           </Row>
         </div>

--- a/frontend/src/pages/Profile.test.jsx
+++ b/frontend/src/pages/Profile.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Profile from './Profile';
+
+const { mockProgressAPI } = vi.hoisted(() => ({
+  mockProgressAPI: {
+    getDashboard: vi.fn(),
+  },
+}));
+
+vi.mock('../api', () => ({
+  progressAPI: mockProgressAPI,
+}));
+
+describe('Profile page', () => {
+  beforeEach(() => {
+    mockProgressAPI.getDashboard.mockReset();
+    mockProgressAPI.getDashboard.mockResolvedValue({
+      data: {
+        words_learned: 12,
+        listening_done: 4,
+        speaking_sessions: 3,
+        total_time_minutes: 90,
+      },
+    });
+  });
+
+  it('loads and displays live progress stats', async () => {
+    render(
+      <AntdApp>
+        <Profile
+          user={{ username: 'tester', email: 'tester@example.com', created_at: '2026-03-01T00:00:00Z' }}
+        />
+      </AntdApp>
+    );
+
+    await waitFor(() => {
+      expect(mockProgressAPI.getDashboard).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText('12')).toBeTruthy();
+    expect(screen.getByText('4')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('1.5h')).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/Speaking.jsx
+++ b/frontend/src/pages/Speaking.jsx
@@ -1,5 +1,6 @@
 import { Typography, Card, Row, Col, Tag } from 'antd';
 import { AudioOutlined, MessageOutlined, TrophyOutlined } from '@ant-design/icons';
+import useLearningTimeTracker from '../hooks/useLearningTimeTracker';
 
 const { Title, Text } = Typography;
 
@@ -10,7 +11,7 @@ const modes = [
     color: '#dc2626',
     bg: '#fef2f2',
     desc: 'Record your voice, play back, and compare with native pronunciation.',
-    sprint: 'Sprint 2',
+    status: 'Coming soon',
   },
   {
     title: 'Structured Speaking',
@@ -18,7 +19,7 @@ const modes = [
     color: '#7c3aed',
     bg: '#f5f3ff',
     desc: 'Pick a topic card, express your thoughts in 30-60 seconds, and get AI feedback.',
-    sprint: 'Sprint 3',
+    status: 'Coming soon',
   },
   {
     title: 'Sentence Follow-along',
@@ -26,11 +27,13 @@ const modes = [
     color: '#059669',
     bg: '#ecfdf5',
     desc: 'Read sentences aloud and see how closely your speech matches the target.',
-    sprint: 'Sprint 2',
+    status: 'Coming soon',
   },
 ];
 
 export default function Speaking() {
+  useLearningTimeTracker('speaking', 'study_time:speaking');
+
   return (
     <div className="page-container">
       <div className="page-header">
@@ -69,7 +72,7 @@ export default function Speaking() {
                 {mode.icon}
               </div>
               <Title level={5} style={{ fontWeight: 600 }}>{mode.title}</Title>
-              <Tag style={{ borderRadius: 12, marginBottom: 12 }}>{mode.sprint}</Tag>
+              <Tag style={{ borderRadius: 12, marginBottom: 12 }}>{mode.status}</Tag>
               <Text type="secondary" style={{ fontSize: 13, display: 'block' }}>
                 {mode.desc}
               </Text>

--- a/frontend/src/pages/WordBank.jsx
+++ b/frontend/src/pages/WordBank.jsx
@@ -11,6 +11,7 @@ import {
   StarOutlined, CloseOutlined
 } from '@ant-design/icons';
 import { wordBankAPI, dailyLearningAPI } from '../api';
+import useLearningTimeTracker from '../hooks/useLearningTimeTracker';
 
 const { Title, Text, Paragraph } = Typography;
 const { Option } = Select;
@@ -23,6 +24,8 @@ const sortOptions = [
 ];
 
 export default function WordBank() {
+  useLearningTimeTracker('vocab', 'study_time:word-bank');
+
   const [words, setWords] = useState([]);
   const [filteredWords, setFilteredWords] = useState([]);
   const [search, setSearch] = useState('');
@@ -81,8 +84,7 @@ export default function WordBank() {
     let filtered = [...words];
     if (search) {
       filtered = filtered.filter(w =>
-        w.text.toLowerCase().includes(search.toLowerCase()) ||
-        w.definition.toLowerCase().includes(search.toLowerCase())
+        w.text.toLowerCase().includes(search.toLowerCase())
       );
     }
     filtered.sort((a, b) => {
@@ -396,7 +398,7 @@ export default function WordBank() {
         {/* Search and Sort */}
         <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
           <Input
-            placeholder="Search words or definitions..."
+            placeholder="Search words..."
             prefix={<SearchOutlined style={{ color: '#9ca3af' }} />}
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/frontend/src/pages/WordBank.test.jsx
+++ b/frontend/src/pages/WordBank.test.jsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import WordBank from './WordBank';
 import { renderWithProviders } from '../test/renderWithProviders';
 
-const { mockWordBankAPI, mockDailyLearningAPI } = vi.hoisted(() => ({
+const { mockWordBankAPI, mockDailyLearningAPI, mockProgressAPI } = vi.hoisted(() => ({
   mockWordBankAPI: {
     getAll: vi.fn(),
     add: vi.fn(),
@@ -21,17 +21,23 @@ const { mockWordBankAPI, mockDailyLearningAPI } = vi.hoisted(() => ({
     getMasteredWords: vi.fn(),
     markMastered: vi.fn(),
   },
+  mockProgressAPI: {
+    getDashboard: vi.fn(),
+    trackTime: vi.fn(),
+  },
 }));
 
 vi.mock('../api', () => ({
   wordBankAPI: mockWordBankAPI,
   dailyLearningAPI: mockDailyLearningAPI,
+  progressAPI: mockProgressAPI,
 }));
 
 describe('WordBank page', () => {
   beforeEach(() => {
     Object.values(mockWordBankAPI).forEach((fn) => fn.mockReset());
     Object.values(mockDailyLearningAPI).forEach((fn) => fn.mockReset());
+    Object.values(mockProgressAPI).forEach((fn) => fn.mockReset());
   });
 
   it('renders saved words and filters them by search term', async () => {
@@ -66,13 +72,50 @@ describe('WordBank page', () => {
     expect(await screen.findByText('hypothesis')).toBeTruthy();
     expect(await screen.findByText('empirical')).toBeTruthy();
 
-    fireEvent.change(screen.getByPlaceholderText('Search words or definitions...'), {
+    fireEvent.change(screen.getByPlaceholderText('Search words...'), {
       target: { value: 'hypo' },
     });
 
     await waitFor(() => {
       expect(screen.getByText('hypothesis')).toBeTruthy();
       expect(screen.queryByText('empirical')).toBeNull();
+    });
+  });
+
+  it('filters by word text only and ignores definition matches', async () => {
+    mockWordBankAPI.getAll.mockResolvedValue({
+      data: {
+        words: [
+          {
+            id: 1,
+            word_id: 11,
+            text: 'zebra',
+            definition: 'Contains character c in definition.',
+            added_at: '2026-03-18T10:00:00',
+          },
+          {
+            id: 2,
+            word_id: 12,
+            text: 'abacus',
+            definition: 'A counting frame.',
+            added_at: '2026-03-17T10:00:00',
+          },
+        ],
+      },
+    });
+
+    renderWithProviders(<WordBank />);
+
+    expect(await screen.findByText('zebra')).toBeTruthy();
+    expect(await screen.findByText('abacus')).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText('Search words...'), {
+      target: { value: 'c' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('abacus')).toBeTruthy();
+      expect(screen.queryByText('zebra')).toBeNull();
     });
   });
 


### PR DESCRIPTION
### Changes

- Fix listening answer/result persistence so clip switches, page switches, logout/login, and same-user re-entry restore prior progress
- Persist listening submissions in the backend and return saved attempts when the same user revisits a clip
- Add progress dashboard API and connect Profile page to real backend statistics
- Fix Listening Done to count distinct completed listening activities instead of raw submission count
- Add unified study-time tracking across implemented modules: Daily Words, Word Bank, Listening, Speaking, and AI Chat
- Fix daily learning limit logic to prevent same-day over-assignment and handle limit increases/decreases correctly
- Fix Word Bank search to match only word text, not definition content
- Standardize unfinished-feature labels to Coming soon
- Run full backend and frontend test suites and update Sprint 1 unit-test documentation with current results and coverage

### Files Changed

- backend/app/routes/listening.py - Added saved listening-attempt persistence and restore support
- backend/app/routes/progress.py - Added dashboard aggregation and study-time tracking APIs
- backend/app/routes/daily_learning.py - Fixed daily limit allocation and reduced-limit visibility behavior
- backend/app/__init__.py - Registered new models/routes for persistence support
- backend/app/models/listening_attempt.py - New persisted listening-attempt model
- backend/app/models/__init__.py - Exported new listening attempt model
- frontend/src/pages/Listening.jsx - Restored saved listening progress across navigation and backend reloads
- frontend/src/pages/Profile.jsx - Switched profile metrics from hardcoded values to live dashboard data
- frontend/src/pages/DailyWords.jsx - Hooked page into shared study-time tracking
- frontend/src/pages/WordBank.jsx - Fixed search behavior and added study-time tracking
- frontend/src/pages/Speaking.jsx - Standardized placeholder label and added study-time tracking
- frontend/src/pages/AIChat.jsx - Standardized placeholder label and added study-time tracking
- frontend/src/hooks/useLearningTimeTracker.js - New shared frontend study-time tracking hook
- frontend/src/App.jsx - Passed authenticated user into Listening page
- frontend/src/api/index.js - Added progress APIs and updated listening API usage
- backend/tests/test_listening.py - Added saved-attempt persistence coverage
- backend/tests/test_progress.py - Added dashboard and study-time coverage
- backend/tests/test_daily_learning.py - Added daily-limit edge-case coverage
- frontend/src/pages/Listening.test.jsx - Added persistence and backend-restore tests
- frontend/src/pages/Profile.test.jsx - New profile dashboard test
- frontend/src/pages/WordBank.test.jsx - Added word-text-only search test
- docs/unit-test-sprint1.md - Updated test scope, results, and coverage numbers

### How to Test

pytest backend/tests
pytest backend/tests --cov=backend/app --cov-report=term-missing
cd frontend && npm test

### Note for teammates

- Listening progress is now persisted per authenticated user in the backend, so logout/login should no longer clear listening history
- Browser localStorage may still contain UI cache, so for a completely clean manual test run it is still reasonable to clear site data in Chrome in addition to using a fresh account or resetting database records