### PR TITLE
fix ui bug in multiple features

### DIFF
--- a/frontend/src/pages/DailyWords.jsx
+++ b/frontend/src/pages/DailyWords.jsx
@@ -60,6 +60,7 @@ export default function DailyWords() {
   const [allWords, setAllWords] = useState([]);
   const [allWordsTotal, setAllWordsTotal] = useState(0);
   const [allWordsPage, setAllWordsPage] = useState(1);
+  const [allWordsPerPage, setAllWordsPerPage] = useState(20);
   const [allWordsSearch, setAllWordsSearch] = useState('');
   const [allWordsLoading, setAllWordsLoading] = useState(false);
 
@@ -149,11 +150,13 @@ export default function DailyWords() {
     try {
       await dailyLearningAPI.addToBank(wordId);
       setBankIds(prev => new Set([...prev, wordId]));
+      setAllWords(prev => prev.map(w => w.id === wordId ? { ...w, in_word_bank: true } : w));
       message.success('Added to Word Bank!');
     } catch (error) {
       if (error.response?.status === 409) {
         message.info('Already in Word Bank');
         setBankIds(prev => new Set([...prev, wordId]));
+        setAllWords(prev => prev.map(w => w.id === wordId ? { ...w, in_word_bank: true } : w));
       } else {
         message.error('Failed to add to bank');
       }
@@ -242,10 +245,10 @@ export default function DailyWords() {
   };
 
   // ==================== All Words ====================
-  const loadAllWords = async (page = 1, search = '') => {
+  const loadAllWords = async (page = 1, perPage = allWordsPerPage, search = '') => {
     try {
       setAllWordsLoading(true);
-      const res = await dailyLearningAPI.getAllWords(page, 50, search);
+      const res = await dailyLearningAPI.getAllWords(page, perPage, search);
       setAllWords(res.data.words || []);
       setAllWordsTotal(res.data.total || 0);
       setAllWordsPage(page);
@@ -258,7 +261,7 @@ export default function DailyWords() {
 
   const openAllWords = () => {
     setAllWordsSearch('');
-    loadAllWords(1, '');
+    loadAllWords(1, allWordsPerPage, '');
     setAllWordsOpen(true);
   };
 
@@ -789,7 +792,7 @@ export default function DailyWords() {
           value={allWordsSearch}
           onChange={(e) => {
             setAllWordsSearch(e.target.value);
-            loadAllWords(1, e.target.value);
+            loadAllWords(1, allWordsPerPage, e.target.value);
           }}
           allowClear
           style={{ marginBottom: 16 }}
@@ -800,8 +803,17 @@ export default function DailyWords() {
             pagination={{
               current: allWordsPage,
               total: allWordsTotal,
-              pageSize: 50,
-              onChange: (page) => loadAllWords(page, allWordsSearch),
+              pageSize: allWordsPerPage,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50, 100],
+              onChange: (page, pageSize) => {
+                if (pageSize !== allWordsPerPage) {
+                  setAllWordsPerPage(pageSize);
+                  loadAllWords(1, pageSize, allWordsSearch);
+                } else {
+                  loadAllWords(page, pageSize, allWordsSearch);
+                }
+              },
               size: 'small',
             }}
             renderItem={(word) => (
@@ -810,12 +822,12 @@ export default function DailyWords() {
                   <Button
                     key="bank"
                     type="text"
-                    icon={word.in_word_bank ? <CheckOutlined /> : <PlusOutlined />}
-                    disabled={word.in_word_bank}
+                    icon={word.in_word_bank || bankIds.has(word.id) ? <CheckOutlined /> : <PlusOutlined />}
+                    disabled={word.in_word_bank || bankIds.has(word.id)}
                     onClick={() => addToBank(word.id)}
                     size="small"
                   >
-                    {word.in_word_bank ? 'In Bank' : 'Add to Bank'}
+                    {word.in_word_bank || bankIds.has(word.id) ? 'In Bank' : 'Add to Bank'}
                   </Button>,
                   word.progress_status === 'mastered' ? (
                     <Tag key="status" color="green">mastered</Tag>
@@ -866,6 +878,7 @@ export default function DailyWords() {
         <Spin spinning={reviewListLoading}>
           <List
             dataSource={reviewListWords}
+            pagination={{ pageSize: 20, showSizeChanger: true, pageSizeOptions: [10, 20, 50, 100], size: 'small' }}
             renderItem={(word) => (
               <List.Item
                 actions={[
@@ -917,7 +930,7 @@ export default function DailyWords() {
         <Spin spinning={masteredLoading}>
           <List
             dataSource={masteredWords}
-            pagination={{ pageSize: 20 }}
+            pagination={{ pageSize: 20, showSizeChanger: true, pageSizeOptions: [10, 20, 50, 100], size: 'small' }}
             renderItem={(word) => (
               <List.Item
                 actions={[

--- a/frontend/src/pages/Listening.jsx
+++ b/frontend/src/pages/Listening.jsx
@@ -256,7 +256,6 @@ export default function Listening({ user }) {
     const fetchPractice = async () => {
       setPracticeLoading(true);
       setPracticeError('');
-      setPracticeData(null);
       setSubmissionResult(null);
       try {
         const response = await listeningAPI.getPractice(
@@ -701,6 +700,7 @@ export default function Listening({ user }) {
                       borderRadius: 12,
                       border: isSelected ? '1px solid #2563eb' : '1px solid #e5e7eb',
                       background: isSelected ? '#f8fbff' : '#fff',
+                      transition: 'border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease',
                     }}
                     styles={{ body: { padding: 16 } }}
                   >
@@ -771,14 +771,8 @@ export default function Listening({ user }) {
                   />
                 ) : null}
 
-                {practiceLoading ? (
-                  <div style={{ display: 'flex', justifyContent: 'center', padding: '40px 0' }}>
-                    <Spin size="large" />
-                  </div>
-                ) : null}
-
-                {!practiceLoading && practiceData ? (
-                  <>
+                {practiceData ? (
+                  <Spin spinning={practiceLoading}>
                     {submissionResult ? (
                       <Card
                         style={{
@@ -863,10 +857,12 @@ export default function Listening({ user }) {
                         Submit answers
                       </Button>
                     ) : null}
-                  </>
-                ) : null}
-
-                {!practiceLoading && !practiceData && !practiceError ? (
+                  </Spin>
+                ) : practiceLoading ? (
+                  <div style={{ display: 'flex', justifyContent: 'center', padding: '40px 0' }}>
+                    <Spin size="large" />
+                  </div>
+                ) : !practiceError ? (
                   <Empty description="Choose a clip to load its questions." />
                 ) : null}
               </Space>

--- a/frontend/src/pages/WordBank.jsx
+++ b/frontend/src/pages/WordBank.jsx
@@ -43,11 +43,15 @@ export default function WordBank() {
   const [learningIndex, setLearningIndex] = useState(0);
   const [showDef, setShowDef] = useState(false);
 
+  // Track word IDs that are in the bank for immediate button feedback
+  const [bankWordIds, setBankWordIds] = useState(new Set());
+
   // All words / review / mastered modal state
   const [allWordsOpen, setAllWordsOpen] = useState(false);
   const [allWords, setAllWords] = useState([]);
   const [allWordsTotal, setAllWordsTotal] = useState(0);
   const [allWordsPage, setAllWordsPage] = useState(1);
+  const [allWordsPerPage, setAllWordsPerPage] = useState(20);
   const [allWordsSearch, setAllWordsSearch] = useState('');
   const [allWordsLoading, setAllWordsLoading] = useState(false);
 
@@ -78,6 +82,11 @@ export default function WordBank() {
   useEffect(() => {
     loadWordBank();
   }, []);
+
+  // Keep bankWordIds in sync with loaded word bank
+  useEffect(() => {
+    setBankWordIds(new Set(words.map(w => w.word_id)));
+  }, [words]);
 
   // ==================== Filtering & Sorting ====================
   useEffect(() => {
@@ -236,21 +245,24 @@ export default function WordBank() {
   const addToBank = async (wordId) => {
     try {
       await dailyLearningAPI.addToBank(wordId);
+      setBankWordIds(prev => new Set([...prev, wordId]));
+      setAllWords(prev => prev.map(w => w.id === wordId ? { ...w, in_word_bank: true } : w));
       message.success('Added to Word Bank!');
-      loadWordBank();
     } catch (error) {
       if (error.response?.status === 409) {
         message.info('Already in Word Bank');
+        setBankWordIds(prev => new Set([...prev, wordId]));
+        setAllWords(prev => prev.map(w => w.id === wordId ? { ...w, in_word_bank: true } : w));
       } else {
         message.error('Failed to add to bank');
       }
     }
   };
 
-  const loadAllWords = async (page = 1, search = '') => {
+  const loadAllWords = async (page = 1, perPage = allWordsPerPage, search = '') => {
     try {
       setAllWordsLoading(true);
-      const res = await dailyLearningAPI.getAllWords(page, 50, search);
+      const res = await dailyLearningAPI.getAllWords(page, perPage, search);
       setAllWords(res.data.words || []);
       setAllWordsTotal(res.data.total || 0);
       setAllWordsPage(page);
@@ -263,7 +275,7 @@ export default function WordBank() {
 
   const openAllWords = () => {
     setAllWordsSearch('');
-    loadAllWords(1, '');
+    loadAllWords(1, allWordsPerPage, '');
     setAllWordsOpen(true);
   };
 
@@ -625,7 +637,7 @@ export default function WordBank() {
           placeholder="Search words..."
           prefix={<SearchOutlined />}
           value={allWordsSearch}
-          onChange={(e) => { setAllWordsSearch(e.target.value); loadAllWords(1, e.target.value); }}
+          onChange={(e) => { setAllWordsSearch(e.target.value); loadAllWords(1, allWordsPerPage, e.target.value); }}
           allowClear
           style={{ marginBottom: 16 }}
         />
@@ -633,20 +645,32 @@ export default function WordBank() {
           <List
             dataSource={allWords}
             pagination={{
-              current: allWordsPage, total: allWordsTotal, pageSize: 50,
-              onChange: (page) => loadAllWords(page, allWordsSearch), size: 'small',
+              current: allWordsPage,
+              total: allWordsTotal,
+              pageSize: allWordsPerPage,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50, 100],
+              onChange: (page, pageSize) => {
+                if (pageSize !== allWordsPerPage) {
+                  setAllWordsPerPage(pageSize);
+                  loadAllWords(1, pageSize, allWordsSearch);
+                } else {
+                  loadAllWords(page, pageSize, allWordsSearch);
+                }
+              },
+              size: 'small',
             }}
             renderItem={(word) => (
               <List.Item actions={[
                 <Button
                   key="bank"
                   type="text"
-                  icon={word.in_word_bank ? <CheckOutlined /> : <PlusOutlined />}
-                  disabled={word.in_word_bank}
+                  icon={word.in_word_bank || bankWordIds.has(word.id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={word.in_word_bank || bankWordIds.has(word.id)}
                   onClick={() => addToBank(word.id)}
                   size="small"
                 >
-                  {word.in_word_bank ? 'In Bank' : 'Add to Bank'}
+                  {word.in_word_bank || bankWordIds.has(word.id) ? 'In Bank' : 'Add to Bank'}
                 </Button>,
                 word.progress_status === 'mastered' ? (
                   <Tag key="status" color="green">mastered</Tag>
@@ -685,9 +709,19 @@ export default function WordBank() {
         <Spin spinning={reviewListLoading}>
           <List
             dataSource={reviewListWords}
+            pagination={{ pageSize: 20, showSizeChanger: true, pageSizeOptions: [10, 20, 50, 100], size: 'small' }}
             renderItem={(word) => (
               <List.Item actions={[
-                <Button key="bank" type="text" icon={<PlusOutlined />} onClick={() => addToBank(word.word_id)} size="small">Add to Bank</Button>,
+                <Button
+                  key="bank"
+                  type="text"
+                  icon={bankWordIds.has(word.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={bankWordIds.has(word.word_id)}
+                  onClick={() => addToBank(word.word_id)}
+                  size="small"
+                >
+                  {bankWordIds.has(word.word_id) ? 'In Bank' : 'Add to Bank'}
+                </Button>,
               ]}>
                 <List.Item.Meta
                   title={<Space><Text strong>{word.text}</Text><Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} /></Space>}
@@ -711,10 +745,19 @@ export default function WordBank() {
         <Spin spinning={masteredLoading}>
           <List
             dataSource={masteredWords}
-            pagination={{ pageSize: 20 }}
+            pagination={{ pageSize: 20, showSizeChanger: true, pageSizeOptions: [10, 20, 50, 100], size: 'small' }}
             renderItem={(word) => (
               <List.Item actions={[
-                <Button key="bank" type="text" icon={<PlusOutlined />} onClick={() => addToBank(word.word_id)} size="small">Add to Bank</Button>,
+                <Button
+                  key="bank"
+                  type="text"
+                  icon={bankWordIds.has(word.word_id) ? <CheckOutlined /> : <PlusOutlined />}
+                  disabled={bankWordIds.has(word.word_id)}
+                  onClick={() => addToBank(word.word_id)}
+                  size="small"
+                >
+                  {bankWordIds.has(word.word_id) ? 'In Bank' : 'Add to Bank'}
+                </Button>,
               ]}>
                 <List.Item.Meta
                   title={<Space><Text strong>{word.text}</Text><Button type="text" size="small" icon={<SoundOutlined />} onClick={() => speakWord(word.text)} /></Space>}


### PR DESCRIPTION
  UI Refinement: Fix add-to-bank feedback, unify pagination, and resolve listening page flicker

  - Immediate "Add to Bank" button feedback: Fixed the issue where clicking "Add to Bank" did not instantly update the button state to disabled/"In Bank" across all word list
  modals. In Daily Words, the All Words modal was relying solely on server-side in_word_bank flag without updating local state after the action. In Word Bank, the addToBank
  function was calling loadWordBank() which triggered a full data reload causing visual flicker, and the Review/Mastered word modals had no bank-state tracking at all — buttons
  always showed "Add to Bank" regardless of actual status. Introduced local state tracking (bankIds/bankWordIds) with optimistic UI updates so all modals reflect changes
  immediately without page reload.
  - Unified pagination across word list modals: Standardized pagination for all six word list modals (All Words, Review Words, and Mastered Words in both Daily Words and Word Bank
   pages). Previously, All Words had a hardcoded pageSize: 50 that ignored user selection, Review Words had no pagination, and Mastered Words had a fixed pageSize: 20 with no size
   changer. All modals now default to 20 items per page with a working size changer ([10, 20, 50, 100]), and server-side paginated lists correctly pass the selected page size to
  the API.
  - Listening page scroll jump on clip selection: Fixed the layout jump that occurred when selecting a lecture clip while scrolled down. The root cause was that switching clips
  set practiceData to null and replaced the full question list with a small loading spinner, causing the right column to collapse in height and triggering a browser scroll
  position adjustment. Replaced the mutually exclusive render logic with an overlay approach — existing content stays in place behind a semi-transparent <Spin> wrapper during
  loading, preserving layout height and preventing scroll reflow.