### PR TITLE
friend and game share ui

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import WatchTogether from './pages/room/WatchTogether';
 import SpeakingRoom from './pages/room/SpeakingRoom';
 import GameRoom from './pages/room/GameRoom';
 import MyRecords from './pages/room/MyRecords';
+import FriendsModal from './components/FriendsModal';
 import { authAPI } from './api';
 import './App.css';
 
@@ -47,6 +48,7 @@ export default function App() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [scheduleModalVisible, setScheduleModalVisible] = useState(false);
+  const [friendsModalVisible, setFriendsModalVisible] = useState(false);
 
   useEffect(() => {
     authAPI.me()
@@ -91,7 +93,7 @@ export default function App() {
     <ConfigProvider theme={theme}>
       <AntdApp>
         <Layout style={{ minHeight: '100vh', background: '#f0f2f5' }}>
-          {user && !hideNav && <NavBar user={user} onLogout={handleLogout} onScheduleClick={() => setScheduleModalVisible(true)} />}
+          {user && !hideNav && <NavBar user={user} onLogout={handleLogout} onScheduleClick={() => setScheduleModalVisible(true)} onFriendsClick={() => setFriendsModalVisible(true)} />}
           <Content style={{ background: '#f0f2f5' }}>
             <Routes>
               {/* Public routes */}
@@ -194,6 +196,8 @@ export default function App() {
         >
           <Schedule onClose={() => setScheduleModalVisible(false)} />
         </Modal>
+
+        <FriendsModal open={friendsModalVisible} onClose={() => setFriendsModalVisible(false)} />
       </AntdApp>
     </ConfigProvider>
   );

--- a/frontend/src/components/FriendsModal.jsx
+++ b/frontend/src/components/FriendsModal.jsx
@@ -1,0 +1,238 @@
+import { useCallback, useState } from 'react';
+import {
+  App as AntdApp,
+  Avatar,
+  Badge,
+  Button,
+  Empty,
+  Input,
+  List,
+  Modal,
+  Popconfirm,
+  Space,
+  Tabs,
+  Tag,
+  Typography,
+} from 'antd';
+import {
+  CheckOutlined,
+  CloseOutlined,
+  DeleteOutlined,
+  SearchOutlined,
+  UserAddOutlined,
+} from '@ant-design/icons';
+import { friendsAPI } from '../api';
+
+const { Text } = Typography;
+
+export default function FriendsModal({ open, onClose }) {
+  const { message } = AntdApp.useApp();
+  const [friends, setFriends] = useState([]);
+  const [friendRequests, setFriendRequests] = useState({ received: [], sent: [] });
+  const [friendSearchEmail, setFriendSearchEmail] = useState('');
+  const [friendSearchResults, setFriendSearchResults] = useState([]);
+
+  const fetchFriends = useCallback(async () => {
+    try {
+      const [friendRes, reqRes] = await Promise.all([
+        friendsAPI.list(),
+        friendsAPI.getRequests(),
+      ]);
+      setFriends(friendRes.data.friends || []);
+      setFriendRequests(reqRes.data || { received: [], sent: [] });
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const handleSearchFriends = async () => {
+    if (!friendSearchEmail.trim()) return;
+    try {
+      const res = await friendsAPI.search(friendSearchEmail.trim());
+      setFriendSearchResults(res.data.users || []);
+    } catch {
+      message.error('Search failed');
+    }
+  };
+
+  const handleSendFriendRequest = async (email) => {
+    try {
+      await friendsAPI.sendRequest(email);
+      message.success('Friend request sent');
+      handleSearchFriends();
+      fetchFriends();
+    } catch (err) {
+      message.error(err.response?.data?.error || 'Failed to send request');
+    }
+  };
+
+  const handleAcceptFriend = async (requestId) => {
+    try {
+      await friendsAPI.accept(requestId);
+      message.success('Friend request accepted');
+      fetchFriends();
+    } catch (err) {
+      message.error(err.response?.data?.error || 'Failed to accept request');
+    }
+  };
+
+  const handleRejectFriend = async (requestId) => {
+    try {
+      await friendsAPI.reject(requestId);
+      message.success('Friend request rejected');
+      fetchFriends();
+    } catch (err) {
+      message.error(err.response?.data?.error || 'Failed to reject request');
+    }
+  };
+
+  const handleRemoveFriend = async (friendUserId) => {
+    try {
+      await friendsAPI.remove(friendUserId);
+      message.success('Friend removed');
+      fetchFriends();
+    } catch {
+      message.error('Failed to remove friend');
+    }
+  };
+
+  const handleOpen = () => {
+    fetchFriends();
+  };
+
+  return (
+    <Modal
+      title="Manage Friends"
+      open={open}
+      onCancel={() => { onClose(); setFriendSearchEmail(''); setFriendSearchResults([]); }}
+      afterOpenChange={(visible) => { if (visible) handleOpen(); }}
+      footer={null}
+      width={600}
+    >
+      <Tabs items={[
+        {
+          key: 'friends',
+          label: `My Friends (${friends.length})`,
+          children: friends.length === 0 ? (
+            <Empty description="No friends yet" />
+          ) : (
+            <List
+              dataSource={friends}
+              renderItem={(f) => (
+                <List.Item
+                  actions={[
+                    <Popconfirm key="rm" title="Remove this friend?" onConfirm={() => handleRemoveFriend(f.friend_id)}>
+                      <Button size="small" danger icon={<DeleteOutlined />}>Remove</Button>
+                    </Popconfirm>,
+                  ]}
+                >
+                  <List.Item.Meta
+                    avatar={<Avatar style={{ backgroundColor: '#2563eb' }}>{f.friend_username?.charAt(0)?.toUpperCase()}</Avatar>}
+                    title={f.friend_username}
+                    description={f.friend_email}
+                  />
+                </List.Item>
+              )}
+            />
+          ),
+        },
+        {
+          key: 'search',
+          label: 'Find Friends',
+          children: (
+            <div>
+              <Space.Compact style={{ width: '100%', marginBottom: 16 }}>
+                <Input
+                  placeholder="Search by email..."
+                  value={friendSearchEmail}
+                  onChange={(e) => setFriendSearchEmail(e.target.value)}
+                  onPressEnter={handleSearchFriends}
+                />
+                <Button type="primary" icon={<SearchOutlined />} onClick={handleSearchFriends}>Search</Button>
+              </Space.Compact>
+              {friendSearchResults.length > 0 ? (
+                <List
+                  dataSource={friendSearchResults}
+                  renderItem={(u) => (
+                    <List.Item
+                      actions={[
+                        u.is_friend ? (
+                          <Tag key="f" color="green">Already Friends</Tag>
+                        ) : u.has_pending_request ? (
+                          <Tag key="p" color="gold">Request Pending</Tag>
+                        ) : (
+                          <Button key="add" size="small" type="primary" icon={<UserAddOutlined />}
+                            onClick={() => handleSendFriendRequest(u.email)}>
+                            Add Friend
+                          </Button>
+                        ),
+                      ]}
+                    >
+                      <List.Item.Meta
+                        avatar={<Avatar style={{ backgroundColor: '#7c3aed' }}>{u.username?.charAt(0)?.toUpperCase()}</Avatar>}
+                        title={u.username}
+                        description={u.email}
+                      />
+                    </List.Item>
+                  )}
+                />
+              ) : friendSearchEmail ? (
+                <Empty description="No users found" />
+              ) : null}
+            </div>
+          ),
+        },
+        {
+          key: 'requests',
+          label: <Badge count={friendRequests.received?.length || 0} size="small" offset={[8, 0]}>Requests</Badge>,
+          children: (
+            <div>
+              {friendRequests.received?.length > 0 && (
+                <>
+                  <Text strong style={{ display: 'block', marginBottom: 8 }}>Received</Text>
+                  <List
+                    dataSource={friendRequests.received}
+                    renderItem={(r) => (
+                      <List.Item
+                        actions={[
+                          <Button key="a" size="small" type="primary" icon={<CheckOutlined />} onClick={() => handleAcceptFriend(r.id)}>Accept</Button>,
+                          <Button key="r" size="small" danger icon={<CloseOutlined />} onClick={() => handleRejectFriend(r.id)}>Reject</Button>,
+                        ]}
+                      >
+                        <List.Item.Meta
+                          avatar={<Avatar style={{ backgroundColor: '#059669' }}>{r.sender_username?.charAt(0)?.toUpperCase()}</Avatar>}
+                          title={r.sender_username}
+                          description={r.sender_email}
+                        />
+                      </List.Item>
+                    )}
+                  />
+                </>
+              )}
+              {friendRequests.sent?.length > 0 && (
+                <>
+                  <Text strong style={{ display: 'block', marginTop: 16, marginBottom: 8 }}>Sent</Text>
+                  <List
+                    dataSource={friendRequests.sent}
+                    renderItem={(r) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          avatar={<Avatar>{r.receiver_username?.charAt(0)?.toUpperCase()}</Avatar>}
+                          title={r.receiver_username}
+                          description={<Tag color={r.status === 'pending' ? 'gold' : r.status === 'accepted' ? 'green' : 'red'}>{r.status}</Tag>}
+                        />
+                      </List.Item>
+                    )}
+                  />
+                </>
+              )}
+              {(!friendRequests.received?.length && !friendRequests.sent?.length) && (
+                <Empty description="No friend requests" />
+              )}
+            </div>
+          ),
+        },
+      ]} />
+    </Modal>
+  );
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, Layout, Button, Space, Avatar, Dropdown } from 'antd';
+import { Menu, Layout, Button, Space, Avatar, Dropdown, Badge } from 'antd';
 import {
   HomeOutlined,
   ReadOutlined,
@@ -10,6 +10,7 @@ import {
   LogoutOutlined,
   AppstoreOutlined,
   CalendarOutlined,
+  TeamOutlined,
 } from '@ant-design/icons';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -24,7 +25,7 @@ const menuItems = [
   { key: '/room', icon: <AppstoreOutlined />, label: 'Room' },
 ];
 
-export default function NavBar({ user, onLogout, onScheduleClick }) {
+export default function NavBar({ user, onLogout, onScheduleClick, onFriendsClick, friendRequestCount = 0 }) {
   const navigate = useNavigate();
   const location = useLocation();
   const selectedKey = (
@@ -103,6 +104,24 @@ export default function NavBar({ user, onLogout, onScheduleClick }) {
       >
         Schedule
       </Button>
+      <Badge count={friendRequestCount} size="small">
+        <Button
+          type="text"
+          icon={<TeamOutlined />}
+          onClick={onFriendsClick}
+          style={{
+            color: '#e5e7eb',
+            fontSize: 14,
+            fontWeight: 500,
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          Friends
+        </Button>
+      </Badge>
       <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
         <Space style={{ cursor: 'pointer' }}>
           <Avatar

--- a/frontend/src/pages/Forum.jsx
+++ b/frontend/src/pages/Forum.jsx
@@ -4,7 +4,6 @@ import {
   App as AntdApp,
   AutoComplete,
   Avatar,
-  Badge,
   Button,
   Card,
   Empty,
@@ -38,9 +37,7 @@ import {
   PushpinOutlined,
   SearchOutlined,
   ShareAltOutlined,
-  TeamOutlined,
   UploadOutlined,
-  UserAddOutlined,
   UserOutlined,
   VideoCameraOutlined,
   PlayCircleOutlined,
@@ -49,7 +46,7 @@ import { useNavigate } from 'react-router-dom';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { forumAPI, friendsAPI } from '../api';
+import { forumAPI } from '../api';
 import { getVideoInfo } from './VideoPlayer';
 
 const { Title, Text, Paragraph } = Typography;
@@ -224,14 +221,6 @@ export default function Forum({ user }) {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
 
-  // Friend management
-  const [friendsOpen, setFriendsOpen] = useState(false);
-  const [friends, setFriends] = useState([]);
-  const [friendRequests, setFriendRequests] = useState({ received: [], sent: [] });
-  const [friendSearchEmail, setFriendSearchEmail] = useState('');
-  const [friendSearchResults, setFriendSearchResults] = useState([]);
-  const [friendsLoading, setFriendsLoading] = useState(false);
-
   const [createOpen, setCreateOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createForm] = Form.useForm();
@@ -341,70 +330,6 @@ export default function Forum({ user }) {
     navigate(`/listening/video/${videoRef.categoryId}/${videoRef.videoId}?fromForum=true`);
   };
 
-  const fetchFriends = useCallback(async () => {
-    try {
-      const [friendRes, reqRes] = await Promise.all([
-        friendsAPI.list(),
-        friendsAPI.getRequests(),
-      ]);
-      setFriends(friendRes.data.friends || []);
-      setFriendRequests(reqRes.data || { received: [], sent: [] });
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const handleSearchFriends = async () => {
-    if (!friendSearchEmail.trim()) return;
-    try {
-      const res = await friendsAPI.search(friendSearchEmail.trim());
-      setFriendSearchResults(res.data.users || []);
-    } catch {
-      message.error('Search failed');
-    }
-  };
-
-  const handleSendFriendRequest = async (email) => {
-    try {
-      await friendsAPI.sendRequest(email);
-      message.success('Friend request sent');
-      handleSearchFriends();
-      fetchFriends();
-    } catch (err) {
-      message.error(err.response?.data?.error || 'Failed to send request');
-    }
-  };
-
-  const handleAcceptFriend = async (requestId) => {
-    try {
-      await friendsAPI.accept(requestId);
-      message.success('Friend request accepted');
-      fetchFriends();
-    } catch (err) {
-      message.error(err.response?.data?.error || 'Failed to accept request');
-    }
-  };
-
-  const handleRejectFriend = async (requestId) => {
-    try {
-      await friendsAPI.reject(requestId);
-      message.success('Friend request rejected');
-      fetchFriends();
-    } catch (err) {
-      message.error(err.response?.data?.error || 'Failed to reject request');
-    }
-  };
-
-  const handleRemoveFriend = async (friendUserId) => {
-    try {
-      await friendsAPI.remove(friendUserId);
-      message.success('Friend removed');
-      fetchFriends();
-    } catch {
-      message.error('Failed to remove friend');
-    }
-  };
-
   useEffect(() => {
     fetchPosts();
   }, [fetchPosts]);
@@ -413,10 +338,8 @@ export default function Forum({ user }) {
     if (isAdmin) {
       fetchPendingPosts(reviewPage);
       fetchRejectReasons();
-    } else {
-      fetchFriends();
     }
-  }, [fetchPendingPosts, fetchRejectReasons, fetchFriends, isAdmin, reviewPage]);
+  }, [fetchPendingPosts, fetchRejectReasons, isAdmin, reviewPage]);
 
   const refreshDetail = useCallback(async (postId) => {
     try {
@@ -780,13 +703,6 @@ export default function Forum({ user }) {
           </Text>
         </div>
         <Space wrap>
-          {!isAdmin && (
-            <Badge count={friendRequests.received?.length || 0} size="small">
-              <Button icon={<TeamOutlined />} onClick={() => { setFriendsOpen(true); fetchFriends(); }}>
-                Friends
-              </Button>
-            </Badge>
-          )}
           <Button icon={<HistoryOutlined />} onClick={() => { setMyPostsOpen(true); setMyPage(1); fetchMyPosts(1); }}>
             My Posts
           </Button>
@@ -1213,140 +1129,6 @@ export default function Forum({ user }) {
           placeholder="Add a comment to your forward (optional)..."
           maxLength={500}
         />
-      </Modal>
-
-      {/* Friends Management Modal */}
-      <Modal
-        title="Manage Friends"
-        open={friendsOpen}
-        onCancel={() => { setFriendsOpen(false); setFriendSearchEmail(''); setFriendSearchResults([]); }}
-        footer={null}
-        width={600}
-      >
-        <Tabs items={[
-          {
-            key: 'friends',
-            label: `My Friends (${friends.length})`,
-            children: friends.length === 0 ? (
-              <Empty description="No friends yet" />
-            ) : (
-              <List
-                dataSource={friends}
-                renderItem={(f) => (
-                  <List.Item
-                    actions={[
-                      <Popconfirm key="rm" title="Remove this friend?" onConfirm={() => handleRemoveFriend(f.friend_id)}>
-                        <Button size="small" danger icon={<DeleteOutlined />}>Remove</Button>
-                      </Popconfirm>,
-                    ]}
-                  >
-                    <List.Item.Meta
-                      avatar={<Avatar style={{ backgroundColor: '#2563eb' }}>{f.friend_username?.charAt(0)?.toUpperCase()}</Avatar>}
-                      title={f.friend_username}
-                      description={f.friend_email}
-                    />
-                  </List.Item>
-                )}
-              />
-            ),
-          },
-          {
-            key: 'search',
-            label: 'Find Friends',
-            children: (
-              <div>
-                <Space.Compact style={{ width: '100%', marginBottom: 16 }}>
-                  <Input
-                    placeholder="Search by email..."
-                    value={friendSearchEmail}
-                    onChange={(e) => setFriendSearchEmail(e.target.value)}
-                    onPressEnter={handleSearchFriends}
-                  />
-                  <Button type="primary" icon={<SearchOutlined />} onClick={handleSearchFriends}>Search</Button>
-                </Space.Compact>
-                {friendSearchResults.length > 0 ? (
-                  <List
-                    dataSource={friendSearchResults}
-                    renderItem={(u) => (
-                      <List.Item
-                        actions={[
-                          u.is_friend ? (
-                            <Tag key="f" color="green">Already Friends</Tag>
-                          ) : u.has_pending_request ? (
-                            <Tag key="p" color="gold">Request Pending</Tag>
-                          ) : (
-                            <Button key="add" size="small" type="primary" icon={<UserAddOutlined />}
-                              onClick={() => handleSendFriendRequest(u.email)}>
-                              Add Friend
-                            </Button>
-                          ),
-                        ]}
-                      >
-                        <List.Item.Meta
-                          avatar={<Avatar style={{ backgroundColor: '#7c3aed' }}>{u.username?.charAt(0)?.toUpperCase()}</Avatar>}
-                          title={u.username}
-                          description={u.email}
-                        />
-                      </List.Item>
-                    )}
-                  />
-                ) : friendSearchEmail ? (
-                  <Empty description="No users found" />
-                ) : null}
-              </div>
-            ),
-          },
-          {
-            key: 'requests',
-            label: <Badge count={friendRequests.received?.length || 0} size="small" offset={[8, 0]}>Requests</Badge>,
-            children: (
-              <div>
-                {friendRequests.received?.length > 0 && (
-                  <>
-                    <Text strong style={{ display: 'block', marginBottom: 8 }}>Received</Text>
-                    <List
-                      dataSource={friendRequests.received}
-                      renderItem={(r) => (
-                        <List.Item
-                          actions={[
-                            <Button key="a" size="small" type="primary" icon={<CheckOutlined />} onClick={() => handleAcceptFriend(r.id)}>Accept</Button>,
-                            <Button key="r" size="small" danger icon={<CloseOutlined />} onClick={() => handleRejectFriend(r.id)}>Reject</Button>,
-                          ]}
-                        >
-                          <List.Item.Meta
-                            avatar={<Avatar style={{ backgroundColor: '#059669' }}>{r.sender_username?.charAt(0)?.toUpperCase()}</Avatar>}
-                            title={r.sender_username}
-                            description={r.sender_email}
-                          />
-                        </List.Item>
-                      )}
-                    />
-                  </>
-                )}
-                {friendRequests.sent?.length > 0 && (
-                  <>
-                    <Text strong style={{ display: 'block', marginTop: 16, marginBottom: 8 }}>Sent</Text>
-                    <List
-                      dataSource={friendRequests.sent}
-                      renderItem={(r) => (
-                        <List.Item>
-                          <List.Item.Meta
-                            avatar={<Avatar>{r.receiver_username?.charAt(0)?.toUpperCase()}</Avatar>}
-                            title={r.receiver_username}
-                            description={<Tag color={r.status === 'pending' ? 'gold' : r.status === 'accepted' ? 'green' : 'red'}>{r.status}</Tag>}
-                          />
-                        </List.Item>
-                      )}
-                    />
-                  </>
-                )}
-                {(!friendRequests.received?.length && !friendRequests.sent?.length) && (
-                  <Empty description="No friend requests" />
-                )}
-              </div>
-            ),
-          },
-        ]} />
       </Modal>
 
       <Modal

--- a/frontend/src/pages/room/GameRoom.jsx
+++ b/frontend/src/pages/room/GameRoom.jsx
@@ -74,6 +74,7 @@ export default function GameRoom({ user }) {
   const [gamePhase, setGamePhase] = useState('waiting'); // waiting | playing | roundResult | gameOver
   const [roundResult, setRoundResult] = useState(null);
   const [finalResults, setFinalResults] = useState(null);
+  const [roundsLog, setRoundsLog] = useState([]);
   const [showLeave, setShowLeave] = useState(false);
   const [shakeKey, setShakeKey] = useState(0);
   const [showShareModal, setShowShareModal] = useState(false);
@@ -204,6 +205,7 @@ export default function GameRoom({ user }) {
       setSubmittedPlayers({});
       setRoundResult(null);
       setFinalResults(data.results || []);
+      setRoundsLog(data.rounds_log || []);
       setGamePhase('gameOver');
     });
 
@@ -294,17 +296,72 @@ export default function GameRoom({ user }) {
   const handleShareToForum = useCallback(async () => {
     setShareLoading(true);
     try {
-      const gameLabel = gameTypeRef.current === 'word_duel' ? 'Word Duel' : 'Context Guesser';
+      const isWordDuelType = gameTypeRef.current === 'word_duel';
+      const gameLabel = isWordDuelType ? 'Word Duel' : 'Context Guesser';
       const winner = finalResults?.[0]?.username || 'Unknown';
       const title = `Game Record: ${gameLabel} — ${winner} wins!`;
 
+      // Build player name lookup
+      const playerNames = {};
+      for (const r of (finalResults || [])) {
+        playerNames[r.user_id] = r.username;
+      }
+
+      // Final standings
       const lines = (finalResults || []).map((r, i) => {
         const medals = ['🥇', '🥈', '🥉'];
         const prefix = medals[i] || `${i + 1}.`;
         const time = formatCompletionTime(r.completion_secs);
-        return `${prefix} ${r.username}: ${r.score} pts${time ? ` (${time})` : ''}`;
+        return `${prefix} **${r.username}**: ${r.score} pts${time ? ` (${time})` : ''}`;
       });
-      const content = `🎮 ${gameLabel} — Final Results\n\n${lines.join('\n')}`;
+
+      let content = `🎮 **${gameLabel}** — Final Results\n\n${lines.join('\n')}`;
+
+      // Round-by-round details
+      if (roundsLog && roundsLog.length > 0) {
+        content += '\n\n---\n\n📝 **Round-by-Round Details**\n';
+
+        roundsLog.forEach((round, idx) => {
+          content += `\n**Round ${idx + 1}**\n`;
+
+          // Question
+          const question = round.question || round.sentence || '';
+          if (question) {
+            content += `Q: ${question}\n`;
+          }
+          if (round.revealed_sentence) {
+            content += `Sentence: ${round.revealed_sentence}\n`;
+          }
+
+          // Correct answer
+          const correctAnswer = Array.isArray(round.correct_answers)
+            ? round.correct_answers.join(', ')
+            : round.correct_answer || '';
+          if (correctAnswer) {
+            content += `✅ Correct answer: \`${correctAnswer}\`\n`;
+          }
+
+          // Each player's answer
+          if (round.answers) {
+            for (const [uid, submission] of Object.entries(round.answers)) {
+              const name = playerNames[uid] || playerNames[Number(uid)] || `Player ${uid}`;
+              if (!isWordDuelType && Array.isArray(submission?.answers)) {
+                // Context Guesser: multiple blanks
+                const parts = submission.answers.map((ans, i) => {
+                  const ok = submission.correct_mask?.[i];
+                  return ok ? `${ans} ✅` : `${ans} ❌`;
+                });
+                content += `- ${name}: ${parts.join(', ')}\n`;
+              } else {
+                // Word Duel: single answer
+                const ans = submission?.answer ?? submission;
+                const isCorrect = submission?.correct ?? (round.winner_user_id === Number(uid));
+                content += `- ${name}: ${ans || '(no answer)'} ${isCorrect ? '✅' : '❌'}\n`;
+              }
+            }
+          }
+        });
+      }
 
       const formData = new FormData();
       formData.append('title', title);
@@ -322,7 +379,7 @@ export default function GameRoom({ user }) {
     } finally {
       setShareLoading(false);
     }
-  }, [finalResults, shareZone, message, roomId]);
+  }, [finalResults, roundsLog, shareZone, message, roomId]);
 
   const handleLeave = useCallback(async () => {
     if (isLeavingRef.current) {


### PR DESCRIPTION
Move Friends button to global NavBar and enhance game record sharing

Friends button relocation: Extracted the friend management feature (friend list, search, requests) from the Forum page into a standalone FriendsModal component and placed the trigger button in the NavBar next to Schedule. This makes the friends feature accessible from any page, not just the Forum.

Game record sharing enhancement: When sharing game results to the forum after a match ends, the post now includes detailed round-by-round information — questions, correct answers, and each player's submissions with correctness indicators — matching the level of detail shown in the game history detail view. Supports both Word Duel and Context Guesser game types.