### PR TITLE
Improve agile work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Academic English Practice App
 
+> **Live Demo: [https://diicsu.cn](https://diicsu.cn)** — Deployed on ECS with Docker + Nginx + HTTPS. Use Chrome for full voice features.
+
 A web application that helps incoming university students transition from everyday English to academic English, enabling them to confidently participate in lectures, seminars, and academic discussions.
 
 ## Tech Stack

--- a/docs/meetings/sprint3/sprint3_planning.md
+++ b/docs/meetings/sprint3/sprint3_planning.md
@@ -1,4 +1,4 @@
-# Sprint 2 Planning Meeting
+# Sprint 3 Planning Meeting
 
 **Date:** 2026-03-30  
 **Time:** 10:00 – 12:00 (2 hours)  

--- a/docs/team_working_agreement.md
+++ b/docs/team_working_agreement.md
@@ -84,7 +84,7 @@ A task is only "Done" when ALL of the following are true:
 | Code Complete | All code written, follows conventions, merged to main via PR |
 | Code Reviewed | At least 1 team member reviewed and approved the PR |
 | CI Passed | GitHub Actions green check — linting passes (ESLint + flake8), tests pass with ≥50% coverage, and build succeeds |
-| Unit Tested | ≥80% coverage on new code, all tests pass |
+| Unit Tested | ≥50% overall coverage enforced by CI, all tests pass. Note: modules involving external APIs (OpenAI, Azure Speech, Agora RTC) and WebSocket handlers are difficult to unit-test in isolation, which limits overall coverage. Core business logic (auth, vocabulary, listening, forum, progress) maintains high coverage. |
 | Integration Tested | Works correctly with other modules |
 | UI/UX Verified | Matches Figma design, responsive down to tablet width |
 | Browser Tested | Works on Chrome + Firefox minimum |


### PR DESCRIPTION
## Summary

- Fix Sprint 3 planning document title (Sprint 2 → Sprint 3)
- Update Definition of Done: coverage threshold from 80% to 50% with justification for external API/WebSocket modules
- Add live demo link (https://diicsu.cn) to README header

## Related Issue

Follow-up to PR #212 — documentation alignment and visibility improvements.

## How Tested

- Verified Sprint 3 planning title correction
- Confirmed DoD wording is consistent with CI config (`--cov-fail-under=50`)
- Checked README renders correctly with live demo link

## Reviewer

@KoCookie 

