### PR TITLE
Enable youtube video without proxy

### DIFF
--- a/backend/app/routes/proxy.py
+++ b/backend/app/routes/proxy.py
@@ -101,7 +101,14 @@ def _resolve_youtube(video_id):
         'noplaylist': True,
         'cachedir': False,
         'format': YTDL_FORMAT,
-        'extractor_args': {'youtube': {'player_client': ['web']}},
+        # The 'web' client no longer returns any progressive (muxed) mp4
+        # for most videos — only DASH (split audio+video). Since proxy.py
+        # streams a single URL directly to the browser without ffmpeg
+        # merging, we need a client that still serves itag 18 (360p mp4
+        # progressive). 'android' is the only client that consistently
+        # returns it; 'web' is kept as fallback for the rare case android
+        # is throttled.
+        'extractor_args': {'youtube': {'player_client': ['android', 'web']}},
     }
     proxy_url = _get_proxy_url()
     if proxy_url:


### PR DESCRIPTION
## Summary
Fix `/api/proxy/youtube/<id>/stream` always returning `Requested format is
not available`. YouTube's `web` player_client no longer returns progressive
(muxed) mp4 for most videos — only split DASH streams. Since `proxy.py`
streams a single URL directly to the browser without ffmpeg merging, it
fails outright when no progressive format is available. Switch to
`android` as the primary client (currently the only one that still
reliably returns itag 18 / 360p progressive mp4), keeping `web` as a
fallback. One-line change plus an inline comment explaining why.

## How Tested
Re-ran the existing `YTDL_FORMAT` filter against three globally-available
videos from the production ECS container:

| video | before (`web`) | after (`android, web`) |
|---|---|---|
| `dQw4w9WgXcQ` (Rick Astley) | Requested format is not available | ✅ 360p mp4, signed url |
| `jNQXAC9IVRw` (Me at the zoo) | Requested format is not available | ✅ 240p mp4, signed url |
| `9bZkp7q19f0` (Gangnam Style) | Requested format is not available | ✅ 360p mp4, signed url |

`test_proxy.py` mocks `YoutubeDL` and `httpx.Client`, so this
`extractor_args` change needs no unit test updates.

## Reviewer
@RainYans 

